### PR TITLE
feat: Profile Edit - PUT /user/update endpoint with JWT auth

### DIFF
--- a/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
@@ -7,8 +7,10 @@ import jakarta.validation.constraints.NotBlank;
 import org.fitznet.fitznetapi.dto.UserDTO;
 import org.fitznet.fitznetapi.dto.requests.DeleteUserRequestDto;
 import org.fitznet.fitznetapi.dto.requests.LoginRequestDto;
+import org.fitznet.fitznetapi.dto.requests.UpdateProfileRequestDto;
 import org.fitznet.fitznetapi.dto.requests.UpdateUserRequestDto;
 import org.fitznet.fitznetapi.dto.responses.LoginResponseDto;
+import org.fitznet.fitznetapi.dto.responses.UpdateProfileResponseDto;
 import org.fitznet.fitznetapi.model.User;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.UserService;
@@ -17,10 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -69,8 +74,48 @@ public class UserController {
 
   @PatchMapping("/user/update")
   public void updateUser(@RequestBody @Valid UpdateUserRequestDto updateUserDto) {
-    log.info("Request for /update");
+    log.info("Request for /update (PATCH)");
     userService.updateUser(updateUserDto);
+  }
+
+  @PutMapping("/user/update")
+  public UpdateProfileResponseDto updateProfile(@RequestBody @Valid UpdateProfileRequestDto profileRequest) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String currentUsername = auth.getName();
+    log.info("Request for /user/update (PUT) - authenticated user: {}", currentUsername);
+
+    // Map the simple profile request to the internal update DTO
+    UpdateUserRequestDto updateDto = new UpdateUserRequestDto();
+    updateDto.setUsername(currentUsername);
+
+    boolean hasUpdates = false;
+
+    if (profileRequest.getUsername() != null && !profileRequest.getUsername().equals(currentUsername)) {
+      updateDto.setUpdatedUsername(profileRequest.getUsername());
+      hasUpdates = true;
+    }
+
+    if (profileRequest.getEmail() != null) {
+      updateDto.setUpdatedEmail(profileRequest.getEmail());
+      hasUpdates = true;
+    }
+
+    if (profileRequest.getPassword() != null && !profileRequest.getPassword().isBlank()) {
+      updateDto.setUpdatedPassword(profileRequest.getPassword());
+      hasUpdates = true;
+    }
+
+    if (!hasUpdates) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No fields to update");
+    }
+
+    User updatedUser = userService.updateUser(updateDto);
+
+    if (updatedUser == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+    }
+
+    return new UpdateProfileResponseDto(true, "Profile updated successfully", updatedUser.getUsername(), updatedUser.getEmail());
   }
 
   @PostMapping("/user/login")

--- a/src/main/java/org/fitznet/fitznetapi/dto/requests/UpdateProfileRequestDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/requests/UpdateProfileRequestDto.java
@@ -1,0 +1,19 @@
+package org.fitznet.fitznetapi.dto.requests;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(exclude = "password")
+public class UpdateProfileRequestDto {
+  @NotBlank String username;
+  @NotBlank @Email String email;
+  String password;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/responses/UpdateProfileResponseDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/responses/UpdateProfileResponseDto.java
@@ -1,0 +1,16 @@
+package org.fitznet.fitznetapi.dto.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileResponseDto {
+  boolean success;
+  String message;
+  String username;
+  String email;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/service/UserService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/UserService.java
@@ -38,17 +38,18 @@ public class UserService {
     return userRepository.findByUsername(username);
   }
 
-  public void updateUser(UpdateUserRequestDto updateRequest) {
+  public User updateUser(UpdateUserRequestDto updateRequest) {
     log.info("Updating user: {}", updateRequest.getUsername());
 
     User updatedUser = userRepository.findAndModifyUser(updateRequest);
 
     if (updatedUser == null) {
       log.warn("User not found or no fields to update: {}", updateRequest.getUsername());
-      return;
+      return null;
     }
 
     log.info("User updated successfully: {}", updateRequest.getUsername());
+    return updatedUser;
   }
 
   public boolean verifyPassword(String username, String rawPassword) {

--- a/src/test/java/org/fitznet/fitznetapi/controller/UserControllerTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/controller/UserControllerTest.java
@@ -10,8 +10,10 @@ import java.util.List;
 import org.fitznet.fitznetapi.dto.UserDTO;
 import org.fitznet.fitznetapi.dto.requests.DeleteUserRequestDto;
 import org.fitznet.fitznetapi.dto.requests.LoginRequestDto;
+import org.fitznet.fitznetapi.dto.requests.UpdateProfileRequestDto;
 import org.fitznet.fitznetapi.dto.requests.UpdateUserRequestDto;
 import org.fitznet.fitznetapi.dto.responses.LoginResponseDto;
+import org.fitznet.fitznetapi.dto.responses.UpdateProfileResponseDto;
 import org.fitznet.fitznetapi.model.User;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.UserService;
@@ -22,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.server.ResponseStatusException;
 
 class UserControllerTest {
@@ -43,6 +47,7 @@ class UserControllerTest {
 
   @AfterEach
   public void tearDown() throws Exception {
+    SecurityContextHolder.clearContext();
     if (mocks != null) {
       mocks.close(); // Properly clean up resources
     }
@@ -153,7 +158,8 @@ class UserControllerTest {
     UpdateUserRequestDto updateUserRequestDto =
         new UpdateUserRequestDto("mattlol85", "newUsername", "newEmail@example.com", "newEmail@example.com", "newPassword123");
 
-    doNothing().when(userService).updateUser(any(UpdateUserRequestDto.class));
+    User updatedUser = User.builder().username("newUsername").email("newEmail@example.com").build();
+    when(userService.updateUser(any(UpdateUserRequestDto.class))).thenReturn(updatedUser);
 
     userController.updateUser(updateUserRequestDto);
 
@@ -198,5 +204,93 @@ class UserControllerTest {
     assertEquals("Invalid username or password", exception.getReason());
     verify(userService, times(1)).verifyPassword("mattlol85", "wrongPassword");
     verify(userService, times(0)).readByUsername(any());
+  }
+
+  @Test
+  void updateProfileShouldReturnUpdatedUserWhenSuccessful() {
+    // Set up security context with authenticated user
+    UsernamePasswordAuthenticationToken auth =
+        new UsernamePasswordAuthenticationToken("mattlol85", null, null);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    UpdateProfileRequestDto profileRequest = new UpdateProfileRequestDto("newUsername", "new@example.com", "newPassword123");
+
+    User updatedUser = User.builder()
+        .username("newUsername")
+        .email("new@example.com")
+        .password("$2a$10$hashedPassword")
+        .build();
+
+    when(userService.updateUser(any(UpdateUserRequestDto.class))).thenReturn(updatedUser);
+
+    UpdateProfileResponseDto response = userController.updateProfile(profileRequest);
+
+    assertTrue(response.isSuccess());
+    assertEquals("Profile updated successfully", response.getMessage());
+    assertEquals("newUsername", response.getUsername());
+    assertEquals("new@example.com", response.getEmail());
+    verify(userService, times(1)).updateUser(any(UpdateUserRequestDto.class));
+  }
+
+  @Test
+  void updateProfileShouldThrowNotFoundWhenUserDoesNotExist() {
+    UsernamePasswordAuthenticationToken auth =
+        new UsernamePasswordAuthenticationToken("unknownUser", null, null);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    UpdateProfileRequestDto profileRequest = new UpdateProfileRequestDto("newUsername", "new@example.com", null);
+
+    when(userService.updateUser(any(UpdateUserRequestDto.class))).thenReturn(null);
+
+    ResponseStatusException exception =
+        assertThrows(ResponseStatusException.class, () -> userController.updateProfile(profileRequest));
+
+    assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+  }
+
+  @Test
+  void updateProfileShouldUpdateEmailOnlyWhenUsernameUnchanged() {
+    UsernamePasswordAuthenticationToken auth =
+        new UsernamePasswordAuthenticationToken("mattlol85", null, null);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    // Username same as current user, only email changes
+    UpdateProfileRequestDto profileRequest = new UpdateProfileRequestDto("mattlol85", "updated@example.com", null);
+
+    User updatedUser = User.builder()
+        .username("mattlol85")
+        .email("updated@example.com")
+        .password("$2a$10$hashedPassword")
+        .build();
+
+    when(userService.updateUser(any(UpdateUserRequestDto.class))).thenReturn(updatedUser);
+
+    UpdateProfileResponseDto response = userController.updateProfile(profileRequest);
+
+    assertTrue(response.isSuccess());
+    assertEquals("mattlol85", response.getUsername());
+    assertEquals("updated@example.com", response.getEmail());
+  }
+
+  @Test
+  void updateProfileShouldUpdatePasswordWhenProvided() {
+    UsernamePasswordAuthenticationToken auth =
+        new UsernamePasswordAuthenticationToken("mattlol85", null, null);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    UpdateProfileRequestDto profileRequest = new UpdateProfileRequestDto("mattlol85", "test@example.com", "newSecurePassword");
+
+    User updatedUser = User.builder()
+        .username("mattlol85")
+        .email("test@example.com")
+        .password("$2a$10$newHashedPassword")
+        .build();
+
+    when(userService.updateUser(any(UpdateUserRequestDto.class))).thenReturn(updatedUser);
+
+    UpdateProfileResponseDto response = userController.updateProfile(profileRequest);
+
+    assertTrue(response.isSuccess());
+    verify(userService, times(1)).updateUser(any(UpdateUserRequestDto.class));
   }
 }

--- a/src/test/java/org/fitznet/fitznetapi/service/UserServiceTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/UserServiceTest.java
@@ -114,8 +114,10 @@ class UserServiceTest {
 
     when(userRepository.findAndModifyUser(updateUserRequestDto)).thenReturn(user);
 
-    userService.updateUser(updateUserRequestDto);
+    User result = userService.updateUser(updateUserRequestDto);
 
+    assertNotNull(result);
+    assertEquals(newUsername, result.getUsername());
     verify(userRepository, times(1)).findAndModifyUser(updateUserRequestDto);
   }
 
@@ -134,13 +136,14 @@ class UserServiceTest {
 
     when(userRepository.findAndModifyUser(updateUserRequestDto)).thenReturn(user);
 
-    userService.updateUser(updateUserRequestDto);
+    User result = userService.updateUser(updateUserRequestDto);
 
+    assertNotNull(result);
     verify(userRepository, times(1)).findAndModifyUser(updateUserRequestDto);
   }
 
   @Test
-  void updateUserShouldDoNothingWhenUserDoesNotExist() {
+  void updateUserShouldReturnNullWhenUserDoesNotExist() {
     String oldUsername = "unknownUser";
     String newUsername = "newUser";
     UpdateUserRequestDto updateUserRequestDto =
@@ -148,8 +151,9 @@ class UserServiceTest {
 
     when(userRepository.findAndModifyUser(updateUserRequestDto)).thenReturn(null);
 
-    userService.updateUser(updateUserRequestDto);
+    User result = userService.updateUser(updateUserRequestDto);
 
+    assertNull(result);
     verify(userRepository, times(1)).findAndModifyUser(updateUserRequestDto);
   }
 


### PR DESCRIPTION
## Changes

### Backend (fitz-net-api)
- Add `UpdateProfileRequestDto` accepting `{ username, email, password }`
- Add `UpdateProfileResponseDto` returning `{ success, message, username, email }`
- Add `PUT /user/update` endpoint that identifies user from JWT SecurityContext
- Update `UserService.updateUser` to return updated `User` entity
- Add 4 controller tests for profile update (success, not found, email-only, password)
- Update 3 service tests for new return type

### Related
- Frontend PR: mattlol85/fitz-net-website feature/profileEdit