### PR TITLE
Add Overwatch tracker API support

### DIFF
--- a/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
@@ -56,6 +56,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/user/read", "/user/readAll", "/user/update", "/user/delete")
                     .authenticated()
+                    .requestMatchers("/overwatch/**")
+                    .authenticated()
                     .anyRequest()
                     .authenticated())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/org/fitznet/fitznetapi/controller/OverwatchController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/OverwatchController.java
@@ -5,11 +5,13 @@ import java.util.List;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileRequestDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchSeasonHistoryDto;
 import org.fitznet.fitznetapi.service.OverwatchService;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -50,6 +52,16 @@ public class OverwatchController {
   @GetMapping("/leaderboard")
   public List<OverwatchProfileDto> leaderboard() {
     return overwatchService.getLeaderboard();
+  }
+
+  @GetMapping("/me/history")
+  public OverwatchSeasonHistoryDto myHistory(Authentication authentication) {
+    return overwatchService.getHistory(authentication.getName());
+  }
+
+  @GetMapping("/{playerId}/history")
+  public OverwatchSeasonHistoryDto history(@PathVariable String playerId) {
+    return overwatchService.getHistoryForPlayer(playerId);
   }
 
   private OverwatchProfileDto attachProfile(

--- a/src/main/java/org/fitznet/fitznetapi/controller/OverwatchController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/OverwatchController.java
@@ -1,0 +1,60 @@
+package org.fitznet.fitznetapi.controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileRequestDto;
+import org.fitznet.fitznetapi.service.OverwatchService;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/overwatch")
+public class OverwatchController {
+
+  private final OverwatchService overwatchService;
+
+  public OverwatchController(OverwatchService overwatchService) {
+    this.overwatchService = overwatchService;
+  }
+
+  @GetMapping("/search")
+  public List<OverwatchPlayerSearchResultDto> search(@RequestParam String name) {
+    return overwatchService.searchPlayers(name);
+  }
+
+  @PostMapping("/profile")
+  public OverwatchProfileDto createProfile(
+      @RequestBody @Valid OverwatchProfileRequestDto request, Authentication authentication) {
+    return attachProfile(request, authentication);
+  }
+
+  @PutMapping("/profile")
+  public OverwatchProfileDto updateProfile(
+      @RequestBody @Valid OverwatchProfileRequestDto request, Authentication authentication) {
+    return attachProfile(request, authentication);
+  }
+
+  @GetMapping("/me")
+  public OverwatchProfileDto me(Authentication authentication) {
+    return overwatchService.getProfile(authentication.getName());
+  }
+
+  @GetMapping("/leaderboard")
+  public List<OverwatchProfileDto> leaderboard() {
+    return overwatchService.getLeaderboard();
+  }
+
+  private OverwatchProfileDto attachProfile(
+      OverwatchProfileRequestDto request, Authentication authentication) {
+    return overwatchService.attachProfile(
+        authentication.getName(), request.getPlayerId(), request.getGamemode(), request.getPlatform());
+  }
+}

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastCompetitiveDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastCompetitiveDto.java
@@ -1,0 +1,12 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastCompetitiveDto {
+  private OverfastPlatformRanksDto pc;
+  private OverfastPlatformRanksDto console;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastGeneralStatsDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastGeneralStatsDto.java
@@ -1,0 +1,27 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastGeneralStatsDto {
+  @JsonAlias("games_played")
+  private Integer gamesPlayed;
+
+  @JsonAlias("games_won")
+  private Integer gamesWon;
+
+  @JsonAlias("games_lost")
+  private Integer gamesLost;
+
+  @JsonAlias("time_played")
+  private Integer timePlayed;
+
+  private Double winrate;
+  private Double kda;
+
+  private OverfastStatsTotalsDto total;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastPlatformRanksDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastPlatformRanksDto.java
@@ -1,0 +1,14 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastPlatformRanksDto {
+  private OverfastRoleRankDto tank;
+  private OverfastRoleRankDto damage;
+  private OverfastRoleRankDto support;
+  private OverfastRoleRankDto open;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastPlayerCompleteDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastPlayerCompleteDto.java
@@ -1,0 +1,11 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastPlayerCompleteDto {
+  private OverfastSummaryDto summary;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastRoleRankDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastRoleRankDto.java
@@ -1,0 +1,19 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastRoleRankDto {
+  private String division;
+  private Integer tier;
+
+  @JsonAlias("role_icon")
+  private String roleIcon;
+
+  @JsonAlias("rank_icon")
+  private String rankIcon;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastStatsSummaryResponseDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastStatsSummaryResponseDto.java
@@ -1,0 +1,11 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastStatsSummaryResponseDto {
+  private OverfastGeneralStatsDto general;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastStatsTotalsDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastStatsTotalsDto.java
@@ -1,0 +1,24 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastStatsTotalsDto {
+  private Integer eliminations;
+  private Integer deaths;
+  private Integer damage;
+  private Integer healing;
+
+  @JsonAlias("final_blows")
+  private Integer finalBlows;
+
+  @JsonAlias({"wins", "games_won"})
+  private Integer wins;
+
+  @JsonAlias("games_played")
+  private Integer gamesPlayed;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastSummaryDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overfast/OverfastSummaryDto.java
@@ -1,0 +1,16 @@
+package org.fitznet.fitznetapi.dto.overfast;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverfastSummaryDto {
+  private String username;
+  private String avatar;
+  private String namecard;
+  private String title;
+  private String privacy;
+  private OverfastCompetitiveDto competitive;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchPlayerSearchResultDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchPlayerSearchResultDto.java
@@ -1,0 +1,22 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverwatchPlayerSearchResultDto {
+  @JsonAlias({"playerId", "player_id"})
+  @JsonProperty("playerId")
+  private String playerId;
+
+  private String name;
+  private String avatar;
+  private String privacy;
+
+  @JsonAlias({"careerUrl", "career_url"})
+  @JsonProperty("careerUrl")
+  private String careerUrl;
+}

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchPlayerSummaryDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchPlayerSummaryDto.java
@@ -1,0 +1,17 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OverwatchPlayerSummaryDto {
+  @JsonAlias({"playerId", "player_id"})
+  @JsonProperty("playerId")
+  private String playerId;
+
+  private String name;
+  private String avatar;
+}

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileDto.java
@@ -1,0 +1,23 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class OverwatchProfileDto {
+  String username;
+  String playerId;
+  String displayName;
+  String avatarUrl;
+  Instant lastUpdatedAt;
+  Integer gamesWon;
+  Integer gamesPlayed;
+  Double winrate;
+  Double kda;
+  Integer eliminations;
+  Integer deaths;
+  Integer damage;
+  Integer healing;
+}

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileDto.java
@@ -9,6 +9,7 @@ import lombok.Value;
 public class OverwatchProfileDto {
   String username;
   String playerId;
+  String battleTag;
   String displayName;
   String avatarUrl;
   Instant lastUpdatedAt;
@@ -20,4 +21,8 @@ public class OverwatchProfileDto {
   Integer deaths;
   Integer damage;
   Integer healing;
+
+  Integer dpsRating;
+  Integer tankRating;
+  Integer healsRating;
 }

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileRequestDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileRequestDto.java
@@ -8,7 +8,7 @@ import lombok.Data;
 @Data
 public class OverwatchProfileRequestDto {
   @NotBlank
-  @JsonAlias({"playerId", "player_id"})
+  @JsonAlias({"playerId", "player_id", "battleTag", "battle_tag", "bnetString", "bnet_string"})
   @JsonProperty("playerId")
   private String playerId;
 

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileRequestDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchProfileRequestDto.java
@@ -1,0 +1,17 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class OverwatchProfileRequestDto {
+  @NotBlank
+  @JsonAlias({"playerId", "player_id"})
+  @JsonProperty("playerId")
+  private String playerId;
+
+  private String gamemode;
+  private String platform;
+}

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchRankedMatchDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchRankedMatchDto.java
@@ -1,0 +1,18 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class OverwatchRankedMatchDto {
+  String result;
+  Boolean win;
+  String mode;
+  String map;
+  Integer scoreFor;
+  Integer scoreAgainst;
+  Instant playedAt;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchSeasonHistoryDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchSeasonHistoryDto.java
@@ -1,0 +1,25 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class OverwatchSeasonHistoryDto {
+  String username;
+  String playerId;
+  String battleTag;
+  String displayName;
+  String avatarUrl;
+  String currentSeason;
+  Integer dpsRating;
+  Integer tankRating;
+  Integer healsRating;
+  List<OverwatchSeasonHistoryPointDto> dpsHistory;
+  List<OverwatchSeasonHistoryPointDto> tankHistory;
+  List<OverwatchSeasonHistoryPointDto> healsHistory;
+  List<OverwatchRankedMatchDto> rankedMatches;
+}
+
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchSeasonHistoryPointDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchSeasonHistoryPointDto.java
@@ -1,0 +1,14 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class OverwatchSeasonHistoryPointDto {
+  String label;
+  Integer rating;
+  Instant recordedAt;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchStatsSnapshotDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchStatsSnapshotDto.java
@@ -1,0 +1,17 @@
+package org.fitznet.fitznetapi.dto.overwatch;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class OverwatchStatsSnapshotDto {
+  Integer gamesWon;
+  Integer gamesPlayed;
+  Double winrate;
+  Double kda;
+  Integer eliminations;
+  Integer deaths;
+  Integer damage;
+  Integer healing;
+}

--- a/src/main/java/org/fitznet/fitznetapi/model/User.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/User.java
@@ -1,6 +1,7 @@
 package org.fitznet.fitznetapi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,4 +26,17 @@ public class User {
   String username;
   @JsonIgnore String password;
   String email;
+
+  String overwatchPlayerId;
+  String overwatchDisplayName;
+  String overwatchAvatarUrl;
+  Instant overwatchLastUpdatedAt;
+  Integer overwatchGamesWon;
+  Integer overwatchGamesPlayed;
+  Double overwatchWinrate;
+  Double overwatchKda;
+  Integer overwatchEliminations;
+  Integer overwatchDeaths;
+  Integer overwatchDamage;
+  Integer overwatchHealing;
 }

--- a/src/main/java/org/fitznet/fitznetapi/model/User.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/User.java
@@ -28,6 +28,7 @@ public class User {
   String email;
 
   String overwatchPlayerId;
+  String overwatchBattleTag;
   String overwatchDisplayName;
   String overwatchAvatarUrl;
   Instant overwatchLastUpdatedAt;
@@ -39,4 +40,9 @@ public class User {
   Integer overwatchDeaths;
   Integer overwatchDamage;
   Integer overwatchHealing;
+
+  // Role-specific competitive ratings
+  Integer overwatchDpsRating;
+  Integer overwatchTankRating;
+  Integer overwatchHealsRating;
 }

--- a/src/main/java/org/fitznet/fitznetapi/service/OverwatchClient.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/OverwatchClient.java
@@ -1,15 +1,17 @@
 package org.fitznet.fitznetapi.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Arrays;
 import java.util.List;
+import org.fitznet.fitznetapi.dto.overfast.OverfastPlayerCompleteDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastStatsSummaryResponseDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastSummaryDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 @Component
 public class OverwatchClient {
@@ -26,13 +28,12 @@ public class OverwatchClient {
     OverwatchPlayerSearchResultDto[] players =
         restClient
             .get()
-            .uri(uriBuilder -> uriBuilder.path("/players").queryParam("name", name).build())
+            .uri(b -> b.path("/players").queryParam("name", name).build())
             .retrieve()
             .onStatus(HttpStatusCode::isError, (request, response) -> {
               throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to search Overwatch players");
             })
             .body(OverwatchPlayerSearchResultDto[].class);
-
     return players == null ? List.of() : Arrays.asList(players);
   }
 
@@ -49,28 +50,21 @@ public class OverwatchClient {
               throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to validate Overwatch player");
             })
             .body(OverwatchPlayerSummaryDto.class);
-
     if (summary == null) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Overwatch player not found");
     }
-
     return summary;
   }
 
-  public JsonNode getStatsSummary(String playerId, String gamemode, String platform) {
+  public OverfastStatsSummaryResponseDto getStatsSummary(String playerId, String gamemode, String platform) {
     return restClient
         .get()
-        .uri(
-            uriBuilder -> {
-              var builder = uriBuilder.path("/players/{playerId}/stats/summary");
-              if (gamemode != null && !gamemode.isBlank()) {
-                builder.queryParam("gamemode", gamemode);
-              }
-              if (platform != null && !platform.isBlank()) {
-                builder.queryParam("platform", platform);
-              }
-              return builder.build(playerId);
-            })
+        .uri(b -> {
+          var builder = b.path("/players/{playerId}/stats/summary");
+          if (gamemode != null && !gamemode.isBlank()) builder.queryParam("gamemode", gamemode);
+          if (platform != null && !platform.isBlank()) builder.queryParam("platform", platform);
+          return builder.build(playerId);
+        })
         .retrieve()
         .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
           throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Overwatch stats not found");
@@ -78,6 +72,34 @@ public class OverwatchClient {
         .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
           throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to fetch Overwatch stats");
         })
-        .body(JsonNode.class);
+        .body(OverfastStatsSummaryResponseDto.class);
+  }
+
+  public OverfastPlayerCompleteDto getCompletePlayerInfo(String playerId) {
+    try {
+      return restClient
+          .get()
+          .uri("/players/{playerId}/complete", playerId)
+          .retrieve()
+          .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Overwatch player not found");
+          })
+          .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to fetch Overwatch player data");
+          })
+          .body(OverfastPlayerCompleteDto.class);
+    } catch (ResponseStatusException ex) {
+      if (ex.getStatusCode().value() == HttpStatus.NOT_FOUND.value()) {
+        // Fallback: build a minimal complete DTO from the summary endpoint
+        OverwatchPlayerSummaryDto summaryDto = getPlayerSummary(playerId);
+        OverfastSummaryDto summary = new OverfastSummaryDto();
+        summary.setUsername(summaryDto.getName());
+        summary.setAvatar(summaryDto.getAvatar());
+        OverfastPlayerCompleteDto fallback = new OverfastPlayerCompleteDto();
+        fallback.setSummary(summary);
+        return fallback;
+      }
+      throw ex;
+    }
   }
 }

--- a/src/main/java/org/fitznet/fitznetapi/service/OverwatchClient.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/OverwatchClient.java
@@ -1,0 +1,83 @@
+package org.fitznet.fitznetapi.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Arrays;
+import java.util.List;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+@Component
+public class OverwatchClient {
+
+  private static final String OVERFAST_BASE_URL = "https://overfast-api.tekrop.fr";
+
+  private final RestClient restClient;
+
+  public OverwatchClient(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder.baseUrl(OVERFAST_BASE_URL).build();
+  }
+
+  public List<OverwatchPlayerSearchResultDto> searchPlayers(String name) {
+    OverwatchPlayerSearchResultDto[] players =
+        restClient
+            .get()
+            .uri(uriBuilder -> uriBuilder.path("/players").queryParam("name", name).build())
+            .retrieve()
+            .onStatus(HttpStatusCode::isError, (request, response) -> {
+              throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to search Overwatch players");
+            })
+            .body(OverwatchPlayerSearchResultDto[].class);
+
+    return players == null ? List.of() : Arrays.asList(players);
+  }
+
+  public OverwatchPlayerSummaryDto getPlayerSummary(String playerId) {
+    OverwatchPlayerSummaryDto summary =
+        restClient
+            .get()
+            .uri("/players/{playerId}/summary", playerId)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+              throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Overwatch player not found");
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+              throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to validate Overwatch player");
+            })
+            .body(OverwatchPlayerSummaryDto.class);
+
+    if (summary == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Overwatch player not found");
+    }
+
+    return summary;
+  }
+
+  public JsonNode getStatsSummary(String playerId, String gamemode, String platform) {
+    return restClient
+        .get()
+        .uri(
+            uriBuilder -> {
+              var builder = uriBuilder.path("/players/{playerId}/stats/summary");
+              if (gamemode != null && !gamemode.isBlank()) {
+                builder.queryParam("gamemode", gamemode);
+              }
+              if (platform != null && !platform.isBlank()) {
+                builder.queryParam("platform", platform);
+              }
+              return builder.build(playerId);
+            })
+        .retrieve()
+        .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Overwatch stats not found");
+        })
+        .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+          throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Unable to fetch Overwatch stats");
+        })
+        .body(JsonNode.class);
+  }
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/OverwatchService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/OverwatchService.java
@@ -1,0 +1,263 @@
+package org.fitznet.fitznetapi.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchStatsSnapshotDto;
+import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+public class OverwatchService {
+
+  private final OverwatchClient overwatchClient;
+  private final UserRepository userRepository;
+
+  public OverwatchService(OverwatchClient overwatchClient, UserRepository userRepository) {
+    this.overwatchClient = overwatchClient;
+    this.userRepository = userRepository;
+  }
+
+  public List<OverwatchPlayerSearchResultDto> searchPlayers(String name) {
+    if (name == null || name.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Player name is required");
+    }
+
+    return overwatchClient.searchPlayers(name);
+  }
+
+  public OverwatchProfileDto attachProfile(
+      String username, String playerId, String gamemode, String platform) {
+    if (playerId == null || playerId.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "playerId is required");
+    }
+
+    User user = findUser(username);
+    OverwatchPlayerSummaryDto summary = overwatchClient.getPlayerSummary(playerId);
+    OverwatchStatsSnapshotDto stats =
+        extractStats(overwatchClient.getStatsSummary(playerId, gamemode, platform));
+
+    user.setOverwatchPlayerId(resolvePlayerId(summary, playerId));
+    user.setOverwatchDisplayName(summary.getName());
+    user.setOverwatchAvatarUrl(summary.getAvatar());
+    user.setOverwatchLastUpdatedAt(Instant.now());
+    user.setOverwatchGamesWon(stats.getGamesWon());
+    user.setOverwatchGamesPlayed(stats.getGamesPlayed());
+    user.setOverwatchWinrate(stats.getWinrate());
+    user.setOverwatchKda(stats.getKda());
+    user.setOverwatchEliminations(stats.getEliminations());
+    user.setOverwatchDeaths(stats.getDeaths());
+    user.setOverwatchDamage(stats.getDamage());
+    user.setOverwatchHealing(stats.getHealing());
+
+    User saved = userRepository.save(user);
+    log.info("Attached Overwatch player {} to user {}", saved.getOverwatchPlayerId(), username);
+    return toProfileDto(saved);
+  }
+
+  public OverwatchProfileDto getProfile(String username) {
+    return toProfileDto(findUser(username));
+  }
+
+  public List<OverwatchProfileDto> getLeaderboard() {
+    return userRepository.findAll().stream()
+        .filter(user -> user.getOverwatchPlayerId() != null)
+        .sorted(
+            Comparator.comparing(
+                    OverwatchService::leaderboardScore, Comparator.nullsLast(Comparator.reverseOrder()))
+                .thenComparing(
+                    user -> defaultInteger(user.getOverwatchGamesWon()),
+                    Comparator.reverseOrder())
+                .thenComparing(User::getUsername))
+        .map(this::toProfileDto)
+        .toList();
+  }
+
+  private static Double leaderboardScore(User user) {
+    return user.getOverwatchWinrate();
+  }
+
+  private static Integer defaultInteger(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  private User findUser(String username) {
+    User user = userRepository.findByUsername(username);
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+    }
+    return user;
+  }
+
+  private OverwatchProfileDto toProfileDto(User user) {
+    return OverwatchProfileDto.builder()
+        .username(user.getUsername())
+        .playerId(user.getOverwatchPlayerId())
+        .displayName(user.getOverwatchDisplayName())
+        .avatarUrl(user.getOverwatchAvatarUrl())
+        .lastUpdatedAt(user.getOverwatchLastUpdatedAt())
+        .gamesWon(user.getOverwatchGamesWon())
+        .gamesPlayed(user.getOverwatchGamesPlayed())
+        .winrate(user.getOverwatchWinrate())
+        .kda(user.getOverwatchKda())
+        .eliminations(user.getOverwatchEliminations())
+        .deaths(user.getOverwatchDeaths())
+        .damage(user.getOverwatchDamage())
+        .healing(user.getOverwatchHealing())
+        .build();
+  }
+
+  private static String resolvePlayerId(OverwatchPlayerSummaryDto summary, String requestedPlayerId) {
+    return summary.getPlayerId() == null || summary.getPlayerId().isBlank()
+        ? requestedPlayerId
+        : summary.getPlayerId();
+  }
+
+  private static OverwatchStatsSnapshotDto extractStats(JsonNode statsRoot) {
+    Integer gamesWon = firstInt(statsRoot, "gameswon", "games_won", "games won");
+    Integer gamesPlayed = firstInt(statsRoot, "gamesplayed", "games_played", "games played");
+    Integer eliminations = firstInt(statsRoot, "eliminations", "elims");
+    Integer deaths = firstInt(statsRoot, "deaths");
+    Integer damage = firstInt(statsRoot, "damage", "hero_damage_done", "hero damage done");
+    Integer healing = firstInt(statsRoot, "healing", "healing_done", "healing done");
+    Double winrate = firstDouble(statsRoot, "winrate", "win_rate", "win rate");
+    Double kda = firstDouble(statsRoot, "kda");
+
+    if (winrate == null && gamesWon != null && gamesPlayed != null && gamesPlayed > 0) {
+      winrate = (gamesWon * 100.0) / gamesPlayed;
+    }
+
+    if (kda == null && eliminations != null && deaths != null) {
+      kda = eliminations / (double) Math.max(deaths, 1);
+    }
+
+    return OverwatchStatsSnapshotDto.builder()
+        .gamesWon(gamesWon)
+        .gamesPlayed(gamesPlayed)
+        .winrate(winrate)
+        .kda(kda)
+        .eliminations(eliminations)
+        .deaths(deaths)
+        .damage(damage)
+        .healing(healing)
+        .build();
+  }
+
+  private static Integer firstInt(JsonNode root, String... aliases) {
+    Double value = firstDouble(root, aliases);
+    return value == null ? null : value.intValue();
+  }
+
+  private static Double firstDouble(JsonNode root, String... aliases) {
+    if (root == null) {
+      return null;
+    }
+
+    if (root.isObject()) {
+      Double labeledValue = matchingLabeledValue(root, aliases);
+      if (labeledValue != null) {
+        return labeledValue;
+      }
+
+      var fields = root.fields();
+      while (fields.hasNext()) {
+        var field = fields.next();
+        if (matches(field.getKey(), aliases)) {
+          Double value = numericValue(field.getValue());
+          if (value != null) {
+            return value;
+          }
+        }
+      }
+
+      fields = root.fields();
+      while (fields.hasNext()) {
+        Double nestedValue = firstDouble(fields.next().getValue(), aliases);
+        if (nestedValue != null) {
+          return nestedValue;
+        }
+      }
+    } else if (root.isArray()) {
+      for (JsonNode item : root) {
+        Double nestedValue = firstDouble(item, aliases);
+        if (nestedValue != null) {
+          return nestedValue;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private static Double matchingLabeledValue(JsonNode root, String[] aliases) {
+    String label = textValue(root, "key", "label", "name", "title");
+    if (label == null || !matches(label, aliases)) {
+      return null;
+    }
+
+    for (String valueField : List.of("value", "amount", "total")) {
+      Double value = numericValue(root.get(valueField));
+      if (value != null) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  private static String textValue(JsonNode root, String... fieldNames) {
+    for (String fieldName : fieldNames) {
+      JsonNode value = root.get(fieldName);
+      if (value != null && value.isTextual()) {
+        return value.asText();
+      }
+    }
+    return null;
+  }
+
+  private static Double numericValue(JsonNode value) {
+    if (value == null || value.isNull()) {
+      return null;
+    }
+
+    if (value.isNumber()) {
+      return value.asDouble();
+    }
+
+    if (value.isTextual()) {
+      try {
+        return Double.parseDouble(value.asText().replace("%", "").trim());
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  private static boolean matches(String fieldName, String[] aliases) {
+    String normalizedField = normalize(fieldName);
+    for (String alias : aliases) {
+      if (normalizedField.equals(normalize(alias))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String normalize(String value) {
+    return value == null
+        ? ""
+        : value.toLowerCase(Locale.ROOT).replace("_", "").replace(" ", "");
+  }
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/OverwatchService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/OverwatchService.java
@@ -1,17 +1,28 @@
 package org.fitznet.fitznetapi.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
+import org.fitznet.fitznetapi.dto.overfast.OverfastCompetitiveDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastGeneralStatsDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastPlatformRanksDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastPlayerCompleteDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastRoleRankDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastStatsSummaryResponseDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastStatsTotalsDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastSummaryDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchSeasonHistoryDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchStatsSnapshotDto;
 import org.fitznet.fitznetapi.model.User;
 import org.fitznet.fitznetapi.repository.UserRepository;
+import org.fitznet.fitznetapi.service.overwatch.CompetitiveRatings;
+import org.fitznet.fitznetapi.service.overwatch.HistorySnapshot;
+import org.fitznet.fitznetapi.service.overwatch.PlayerSnapshot;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -28,11 +39,12 @@ public class OverwatchService {
     this.userRepository = userRepository;
   }
 
+  // ---- Public API ----
+
   public List<OverwatchPlayerSearchResultDto> searchPlayers(String name) {
     if (name == null || name.isBlank()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Player name is required");
     }
-
     return overwatchClient.searchPlayers(name);
   }
 
@@ -42,14 +54,21 @@ public class OverwatchService {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "playerId is required");
     }
 
+    String normalizedId = normalizeBattleTag(playerId);
     User user = findUser(username);
-    OverwatchPlayerSummaryDto summary = overwatchClient.getPlayerSummary(playerId);
-    OverwatchStatsSnapshotDto stats =
-        extractStats(overwatchClient.getStatsSummary(playerId, gamemode, platform));
 
-    user.setOverwatchPlayerId(resolvePlayerId(summary, playerId));
-    user.setOverwatchDisplayName(summary.getName());
-    user.setOverwatchAvatarUrl(summary.getAvatar());
+    OverwatchPlayerSummaryDto summary = overwatchClient.getPlayerSummary(normalizedId);
+    OverfastStatsSummaryResponseDto statsSummary = safeGetStatsSummary(normalizedId, gamemode, platform);
+    OverfastPlayerCompleteDto playerComplete = overwatchClient.getCompletePlayerInfo(normalizedId);
+
+    OverwatchStatsSnapshotDto stats = extractStats(statsSummary);
+    CompetitiveRatings ratings = extractCompetitiveRatings(playerComplete);
+    PlayerSnapshot snapshot = extractPlayerSnapshot(playerComplete, summary, normalizedId);
+
+    user.setOverwatchPlayerId(snapshot.getPlayerId());
+    user.setOverwatchBattleTag(snapshot.getBattleTag());
+    user.setOverwatchDisplayName(snapshot.getDisplayName());
+    user.setOverwatchAvatarUrl(snapshot.getAvatarUrl());
     user.setOverwatchLastUpdatedAt(Instant.now());
     user.setOverwatchGamesWon(stats.getGamesWon());
     user.setOverwatchGamesPlayed(stats.getGamesPlayed());
@@ -59,6 +78,9 @@ public class OverwatchService {
     user.setOverwatchDeaths(stats.getDeaths());
     user.setOverwatchDamage(stats.getDamage());
     user.setOverwatchHealing(stats.getHealing());
+    user.setOverwatchDpsRating(ratings.getDpsRating());
+    user.setOverwatchTankRating(ratings.getTankRating());
+    user.setOverwatchHealsRating(ratings.getHealsRating());
 
     User saved = userRepository.save(user);
     log.info("Attached Overwatch player {} to user {}", saved.getOverwatchPlayerId(), username);
@@ -69,74 +91,128 @@ public class OverwatchService {
     return toProfileDto(findUser(username));
   }
 
+  public OverwatchSeasonHistoryDto getHistory(String username) {
+    User user = findUser(username);
+    if (user.getOverwatchPlayerId() == null || user.getOverwatchPlayerId().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No Overwatch profile linked to this account");
+    }
+    return buildHistory(user.getOverwatchPlayerId(), user);
+  }
+
+  public OverwatchSeasonHistoryDto getHistoryForPlayer(String playerId) {
+    if (playerId == null || playerId.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "playerId is required");
+    }
+    return buildHistory(playerId, null);
+  }
+
   public List<OverwatchProfileDto> getLeaderboard() {
     return userRepository.findAll().stream()
-        .filter(user -> user.getOverwatchPlayerId() != null)
+        .filter(u -> u.getOverwatchPlayerId() != null)
         .sorted(
             Comparator.comparing(
                     OverwatchService::leaderboardScore, Comparator.nullsLast(Comparator.reverseOrder()))
                 .thenComparing(
-                    user -> defaultInteger(user.getOverwatchGamesWon()),
-                    Comparator.reverseOrder())
+                    u -> defaultInteger(u.getOverwatchGamesWon()), Comparator.reverseOrder())
                 .thenComparing(User::getUsername))
         .map(this::toProfileDto)
         .toList();
   }
 
-  private static Double leaderboardScore(User user) {
-    return user.getOverwatchWinrate();
-  }
+  // ---- Private helpers ----
 
-  private static Integer defaultInteger(Integer value) {
-    return value == null ? 0 : value;
-  }
+  private OverwatchSeasonHistoryDto buildHistory(String playerId, User linkedUser) {
+    String normalizedId = normalizeBattleTag(playerId);
+    OverwatchPlayerSummaryDto summary = overwatchClient.getPlayerSummary(normalizedId);
+    OverfastPlayerCompleteDto playerComplete = overwatchClient.getCompletePlayerInfo(normalizedId);
 
-  private User findUser(String username) {
-    User user = userRepository.findByUsername(username);
-    if (user == null) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
-    }
-    return user;
-  }
+    CompetitiveRatings ratings = extractCompetitiveRatings(playerComplete);
+    PlayerSnapshot snapshot = extractPlayerSnapshot(playerComplete, summary, normalizedId);
+    HistorySnapshot history = new HistorySnapshot(null, List.of(), List.of(), List.of());
 
-  private OverwatchProfileDto toProfileDto(User user) {
-    return OverwatchProfileDto.builder()
-        .username(user.getUsername())
-        .playerId(user.getOverwatchPlayerId())
-        .displayName(user.getOverwatchDisplayName())
-        .avatarUrl(user.getOverwatchAvatarUrl())
-        .lastUpdatedAt(user.getOverwatchLastUpdatedAt())
-        .gamesWon(user.getOverwatchGamesWon())
-        .gamesPlayed(user.getOverwatchGamesPlayed())
-        .winrate(user.getOverwatchWinrate())
-        .kda(user.getOverwatchKda())
-        .eliminations(user.getOverwatchEliminations())
-        .deaths(user.getOverwatchDeaths())
-        .damage(user.getOverwatchDamage())
-        .healing(user.getOverwatchHealing())
+    return OverwatchSeasonHistoryDto.builder()
+        .username(linkedUser != null ? linkedUser.getUsername() : snapshot.getDisplayName())
+        .playerId(snapshot.getPlayerId())
+        .battleTag(snapshot.getBattleTag())
+        .displayName(snapshot.getDisplayName())
+        .avatarUrl(snapshot.getAvatarUrl())
+        .currentSeason(history.getCurrentSeason())
+        .dpsRating(ratings.getDpsRating())
+        .tankRating(ratings.getTankRating())
+        .healsRating(ratings.getHealsRating())
+        .dpsHistory(history.getDpsHistory())
+        .tankHistory(history.getTankHistory())
+        .healsHistory(history.getHealsHistory())
+        .rankedMatches(List.of())
         .build();
   }
 
-  private static String resolvePlayerId(OverwatchPlayerSummaryDto summary, String requestedPlayerId) {
-    return summary.getPlayerId() == null || summary.getPlayerId().isBlank()
-        ? requestedPlayerId
-        : summary.getPlayerId();
+  private static PlayerSnapshot extractPlayerSnapshot(
+      OverfastPlayerCompleteDto playerComplete,
+      OverwatchPlayerSummaryDto summary,
+      String requestedId) {
+
+    OverfastSummaryDto completeSummary = playerComplete != null ? playerComplete.getSummary() : null;
+
+    String displayName = (completeSummary != null && completeSummary.getUsername() != null)
+        ? completeSummary.getUsername()
+        : (summary != null && summary.getName() != null ? summary.getName() : requestedId);
+
+    String avatarUrl = (completeSummary != null && completeSummary.getAvatar() != null)
+        ? completeSummary.getAvatar()
+        : (summary != null ? summary.getAvatar() : null);
+
+    return new PlayerSnapshot(requestedId, normalizeBattleTag(requestedId), displayName, avatarUrl);
   }
 
-  private static OverwatchStatsSnapshotDto extractStats(JsonNode statsRoot) {
-    Integer gamesWon = firstInt(statsRoot, "gameswon", "games_won", "games won");
-    Integer gamesPlayed = firstInt(statsRoot, "gamesplayed", "games_played", "games played");
-    Integer eliminations = firstInt(statsRoot, "eliminations", "elims");
-    Integer deaths = firstInt(statsRoot, "deaths");
-    Integer damage = firstInt(statsRoot, "damage", "hero_damage_done", "hero damage done");
-    Integer healing = firstInt(statsRoot, "healing", "healing_done", "healing done");
-    Double winrate = firstDouble(statsRoot, "winrate", "win_rate", "win rate");
-    Double kda = firstDouble(statsRoot, "kda");
+  private static CompetitiveRatings extractCompetitiveRatings(OverfastPlayerCompleteDto playerComplete) {
+
+    OverfastSummaryDto completeSummary = playerComplete != null ? playerComplete.getSummary() : null;
+    OverfastCompetitiveDto competitive = completeSummary != null ? completeSummary.getCompetitive() : null;
+
+    if (competitive == null) {
+      return new CompetitiveRatings(null, null, null);
+    }
+
+    OverfastPlatformRanksDto platform = competitive.getPc() != null
+        ? competitive.getPc()
+        : competitive.getConsole();
+
+    if (platform == null) {
+      return new CompetitiveRatings(null, null, null);
+    }
+
+    return new CompetitiveRatings(
+        rankToApproximateSr(platform.getDamage()),
+        rankToApproximateSr(platform.getTank()),
+        rankToApproximateSr(platform.getSupport()));
+  }
+
+  private static OverwatchStatsSnapshotDto extractStats(OverfastStatsSummaryResponseDto statsSummary) {
+    if (statsSummary == null) {
+      return OverwatchStatsSnapshotDto.builder().build();
+    }
+
+    OverfastGeneralStatsDto general = statsSummary.getGeneral();
+    if (general == null) {
+      return OverwatchStatsSnapshotDto.builder().build();
+    }
+
+    OverfastStatsTotalsDto totals = general.getTotal();
+    Integer eliminations = totals != null ? totals.getEliminations() : null;
+    Integer deaths = totals != null ? totals.getDeaths() : null;
+    Integer damage = totals != null ? totals.getDamage() : null;
+    Integer healing = totals != null ? totals.getHealing() : null;
+    Integer gamesWon = general.getGamesWon() != null
+        ? general.getGamesWon()
+        : (totals != null ? totals.getWins() : null);
+    Double winrate = general.getWinrate();
+    Double kda = general.getKda();
+    Integer gamesPlayed = general.getGamesPlayed();
 
     if (winrate == null && gamesWon != null && gamesPlayed != null && gamesPlayed > 0) {
       winrate = (gamesWon * 100.0) / gamesPlayed;
     }
-
     if (kda == null && eliminations != null && deaths != null) {
       kda = eliminations / (double) Math.max(deaths, 1);
     }
@@ -153,111 +229,85 @@ public class OverwatchService {
         .build();
   }
 
-  private static Integer firstInt(JsonNode root, String... aliases) {
-    Double value = firstDouble(root, aliases);
-    return value == null ? null : value.intValue();
-  }
-
-  private static Double firstDouble(JsonNode root, String... aliases) {
-    if (root == null) {
+  /**
+   * Converts an Overwatch 2 competitive rank (division + tier) to an approximate numeric SR.
+   * Each division spans 500 points; tier 5 is the lowest and tier 1 is the highest within a division.
+   */
+  private static Integer rankToApproximateSr(OverfastRoleRankDto rank) {
+    if (rank == null || rank.getDivision() == null) {
       return null;
     }
-
-    if (root.isObject()) {
-      Double labeledValue = matchingLabeledValue(root, aliases);
-      if (labeledValue != null) {
-        return labeledValue;
-      }
-
-      var fields = root.fields();
-      while (fields.hasNext()) {
-        var field = fields.next();
-        if (matches(field.getKey(), aliases)) {
-          Double value = numericValue(field.getValue());
-          if (value != null) {
-            return value;
-          }
-        }
-      }
-
-      fields = root.fields();
-      while (fields.hasNext()) {
-        Double nestedValue = firstDouble(fields.next().getValue(), aliases);
-        if (nestedValue != null) {
-          return nestedValue;
-        }
-      }
-    } else if (root.isArray()) {
-      for (JsonNode item : root) {
-        Double nestedValue = firstDouble(item, aliases);
-        if (nestedValue != null) {
-          return nestedValue;
-        }
-      }
-    }
-
-    return null;
+    int base = switch (rank.getDivision().toLowerCase(Locale.ROOT)) {
+      case "bronze"      -> 0;
+      case "silver"      -> 500;
+      case "gold"        -> 1000;
+      case "platinum"    -> 1500;
+      case "diamond"     -> 2000;
+      case "master"      -> 2500;
+      case "grandmaster" -> 3000;
+      case "champion"    -> 3500;
+      default            -> 0;
+    };
+    int tierOffset = rank.getTier() != null ? (5 - rank.getTier()) * 100 : 0;
+    return base + tierOffset;
   }
 
-  private static Double matchingLabeledValue(JsonNode root, String[] aliases) {
-    String label = textValue(root, "key", "label", "name", "title");
-    if (label == null || !matches(label, aliases)) {
+  private OverfastStatsSummaryResponseDto safeGetStatsSummary(
+      String playerId, String gamemode, String platform) {
+    try {
+      return overwatchClient.getStatsSummary(playerId, gamemode, platform);
+    } catch (Exception e) {
+      log.warn("Could not fetch stats summary for {}: {}", playerId, e.getMessage());
       return null;
     }
-
-    for (String valueField : List.of("value", "amount", "total")) {
-      Double value = numericValue(root.get(valueField));
-      if (value != null) {
-        return value;
-      }
-    }
-
-    return null;
   }
 
-  private static String textValue(JsonNode root, String... fieldNames) {
-    for (String fieldName : fieldNames) {
-      JsonNode value = root.get(fieldName);
-      if (value != null && value.isTextual()) {
-        return value.asText();
-      }
-    }
-    return null;
+  private static Double leaderboardScore(User user) {
+    double sum = 0;
+    int count = 0;
+    if (user.getOverwatchDpsRating() != null)   { sum += user.getOverwatchDpsRating();   count++; }
+    if (user.getOverwatchTankRating() != null)  { sum += user.getOverwatchTankRating();  count++; }
+    if (user.getOverwatchHealsRating() != null) { sum += user.getOverwatchHealsRating(); count++; }
+    return count > 0 ? sum / count : user.getOverwatchWinrate();
   }
 
-  private static Double numericValue(JsonNode value) {
-    if (value == null || value.isNull()) {
-      return null;
-    }
-
-    if (value.isNumber()) {
-      return value.asDouble();
-    }
-
-    if (value.isTextual()) {
-      try {
-        return Double.parseDouble(value.asText().replace("%", "").trim());
-      } catch (NumberFormatException ignored) {
-        return null;
-      }
-    }
-
-    return null;
+  private static Integer defaultInteger(Integer v) {
+    return v == null ? 0 : v;
   }
 
-  private static boolean matches(String fieldName, String[] aliases) {
-    String normalizedField = normalize(fieldName);
-    for (String alias : aliases) {
-      if (normalizedField.equals(normalize(alias))) {
-        return true;
-      }
+  private User findUser(String username) {
+    User user = userRepository.findByUsername(username);
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
     }
-    return false;
+    return user;
   }
 
-  private static String normalize(String value) {
-    return value == null
-        ? ""
-        : value.toLowerCase(Locale.ROOT).replace("_", "").replace(" ", "");
+  private OverwatchProfileDto toProfileDto(User user) {
+    return OverwatchProfileDto.builder()
+        .username(user.getUsername())
+        .playerId(user.getOverwatchPlayerId())
+        .battleTag(user.getOverwatchBattleTag())
+        .displayName(user.getOverwatchDisplayName())
+        .avatarUrl(user.getOverwatchAvatarUrl())
+        .lastUpdatedAt(user.getOverwatchLastUpdatedAt())
+        .gamesWon(user.getOverwatchGamesWon())
+        .gamesPlayed(user.getOverwatchGamesPlayed())
+        .winrate(user.getOverwatchWinrate())
+        .kda(user.getOverwatchKda())
+        .eliminations(user.getOverwatchEliminations())
+        .deaths(user.getOverwatchDeaths())
+        .damage(user.getOverwatchDamage())
+        .healing(user.getOverwatchHealing())
+        .dpsRating(user.getOverwatchDpsRating())
+        .tankRating(user.getOverwatchTankRating())
+        .healsRating(user.getOverwatchHealsRating())
+        .build();
+  }
+
+  private static String normalizeBattleTag(String value) {
+    if (value == null) return null;
+    return value.trim().replace('#', '-').replaceAll("\\s+", "");
   }
 }
+

--- a/src/main/java/org/fitznet/fitznetapi/service/overwatch/CompetitiveRatings.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/overwatch/CompetitiveRatings.java
@@ -1,0 +1,10 @@
+package org.fitznet.fitznetapi.service.overwatch;
+
+import lombok.Value;
+
+@Value
+public class CompetitiveRatings {
+  Integer dpsRating;
+  Integer tankRating;
+  Integer healsRating;
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/overwatch/HistorySnapshot.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/overwatch/HistorySnapshot.java
@@ -1,0 +1,13 @@
+package org.fitznet.fitznetapi.service.overwatch;
+
+import java.util.List;
+import lombok.Value;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchSeasonHistoryPointDto;
+
+@Value
+public class HistorySnapshot {
+  String currentSeason;
+  List<OverwatchSeasonHistoryPointDto> dpsHistory;
+  List<OverwatchSeasonHistoryPointDto> tankHistory;
+  List<OverwatchSeasonHistoryPointDto> healsHistory;
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/overwatch/PlayerSnapshot.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/overwatch/PlayerSnapshot.java
@@ -1,0 +1,11 @@
+package org.fitznet.fitznetapi.service.overwatch;
+
+import lombok.Value;
+
+@Value
+public class PlayerSnapshot {
+  String playerId;
+  String battleTag;
+  String displayName;
+  String avatarUrl;
+}

--- a/src/test/java/org/fitznet/fitznetapi/controller/OverwatchControllerTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/controller/OverwatchControllerTest.java
@@ -1,0 +1,73 @@
+package org.fitznet.fitznetapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSearchResultDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileRequestDto;
+import org.fitznet.fitznetapi.service.OverwatchService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+class OverwatchControllerTest {
+
+  @Mock private OverwatchService overwatchService;
+
+  private AutoCloseable mocks;
+  private OverwatchController overwatchController;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    overwatchController = new OverwatchController(overwatchService);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  void searchShouldReturnPlayerResults() {
+    OverwatchPlayerSearchResultDto player = new OverwatchPlayerSearchResultDto();
+    player.setPlayerId("Matt-1234");
+    player.setName("Matt#1234");
+
+    when(overwatchService.searchPlayers("Matt")).thenReturn(List.of(player));
+
+    List<OverwatchPlayerSearchResultDto> results = overwatchController.search("Matt");
+
+    assertEquals(1, results.size());
+    assertEquals("Matt-1234", results.getFirst().getPlayerId());
+  }
+
+  @Test
+  void updateProfileShouldAttachToAuthenticatedUser() {
+    OverwatchProfileRequestDto request = new OverwatchProfileRequestDto();
+    request.setPlayerId("Matt-1234");
+    request.setGamemode("competitive");
+    request.setPlatform("pc");
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken("matt", null, null);
+    OverwatchProfileDto profile =
+        OverwatchProfileDto.builder().username("matt").playerId("Matt-1234").build();
+
+    when(overwatchService.attachProfile("matt", "Matt-1234", "competitive", "pc"))
+        .thenReturn(profile);
+
+    OverwatchProfileDto result = overwatchController.updateProfile(request, authentication);
+
+    assertEquals("Matt-1234", result.getPlayerId());
+    verify(overwatchService, times(1)).attachProfile("matt", "Matt-1234", "competitive", "pc");
+  }
+}

--- a/src/test/java/org/fitznet/fitznetapi/service/OverwatchServiceTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/OverwatchServiceTest.java
@@ -6,8 +6,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import org.fitznet.fitznetapi.dto.overfast.OverfastGeneralStatsDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastPlayerCompleteDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastStatsSummaryResponseDto;
+import org.fitznet.fitznetapi.dto.overfast.OverfastStatsTotalsDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
 import org.fitznet.fitznetapi.model.User;
@@ -41,31 +44,33 @@ class OverwatchServiceTest {
   }
 
   @Test
-  void attachProfileShouldValidateAndSaveOverwatchStats() throws Exception {
-    ObjectMapper mapper = new ObjectMapper();
+  void attachProfileShouldValidateAndSaveOverwatchStats() {
     User user = User.builder().username("matt").email("matt@example.com").build();
+
     OverwatchPlayerSummaryDto summary = new OverwatchPlayerSummaryDto();
     summary.setPlayerId("Matt-1234");
     summary.setName("Matt#1234");
     summary.setAvatar("https://example.com/avatar.png");
 
+    OverfastStatsTotalsDto totals = new OverfastStatsTotalsDto();
+    totals.setEliminations(2100);
+    totals.setDeaths(700);
+
+    OverfastGeneralStatsDto general = new OverfastGeneralStatsDto();
+    general.setGamesWon(42);
+    general.setGamesPlayed(84);
+    general.setTotal(totals);
+
+    OverfastStatsSummaryResponseDto statsSummary = new OverfastStatsSummaryResponseDto();
+    statsSummary.setGeneral(general);
+
+    // getCompletePlayerInfo returns an empty DTO (no competitive data)
+    OverfastPlayerCompleteDto playerComplete = new OverfastPlayerCompleteDto();
+
     when(userRepository.findByUsername("matt")).thenReturn(user);
     when(overwatchClient.getPlayerSummary("Matt-1234")).thenReturn(summary);
-    when(overwatchClient.getStatsSummary("Matt-1234", "competitive", "pc"))
-        .thenReturn(
-            mapper.readTree(
-                """
-                {
-                  "general": {
-                    "games_won": 42,
-                    "games_played": 84,
-                    "eliminations": 2100,
-                    "deaths": 700,
-                    "damage": 123456,
-                    "healing": 10000
-                  }
-                }
-                """));
+    when(overwatchClient.getStatsSummary("Matt-1234", "competitive", "pc")).thenReturn(statsSummary);
+    when(overwatchClient.getCompletePlayerInfo("Matt-1234")).thenReturn(playerComplete);
     when(userRepository.save(user)).thenReturn(user);
 
     OverwatchProfileDto result =
@@ -110,6 +115,8 @@ class OverwatchServiceTest {
 
     List<OverwatchProfileDto> leaderboard = overwatchService.getLeaderboard();
 
-    assertEquals(List.of("best", "tieWinner", "tieLoser"), leaderboard.stream().map(OverwatchProfileDto::getUsername).toList());
+    assertEquals(
+        List.of("best", "tieWinner", "tieLoser"),
+        leaderboard.stream().map(OverwatchProfileDto::getUsername).toList());
   }
 }

--- a/src/test/java/org/fitznet/fitznetapi/service/OverwatchServiceTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/OverwatchServiceTest.java
@@ -1,0 +1,115 @@
+package org.fitznet.fitznetapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
+import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
+import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class OverwatchServiceTest {
+
+  @Mock private OverwatchClient overwatchClient;
+
+  @Mock private UserRepository userRepository;
+
+  private AutoCloseable mocks;
+  private OverwatchService overwatchService;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    overwatchService = new OverwatchService(overwatchClient, userRepository);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  void attachProfileShouldValidateAndSaveOverwatchStats() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    User user = User.builder().username("matt").email("matt@example.com").build();
+    OverwatchPlayerSummaryDto summary = new OverwatchPlayerSummaryDto();
+    summary.setPlayerId("Matt-1234");
+    summary.setName("Matt#1234");
+    summary.setAvatar("https://example.com/avatar.png");
+
+    when(userRepository.findByUsername("matt")).thenReturn(user);
+    when(overwatchClient.getPlayerSummary("Matt-1234")).thenReturn(summary);
+    when(overwatchClient.getStatsSummary("Matt-1234", "competitive", "pc"))
+        .thenReturn(
+            mapper.readTree(
+                """
+                {
+                  "general": {
+                    "games_won": 42,
+                    "games_played": 84,
+                    "eliminations": 2100,
+                    "deaths": 700,
+                    "damage": 123456,
+                    "healing": 10000
+                  }
+                }
+                """));
+    when(userRepository.save(user)).thenReturn(user);
+
+    OverwatchProfileDto result =
+        overwatchService.attachProfile("matt", "Matt-1234", "competitive", "pc");
+
+    assertEquals("Matt-1234", result.getPlayerId());
+    assertEquals("Matt#1234", result.getDisplayName());
+    assertEquals(42, result.getGamesWon());
+    assertEquals(84, result.getGamesPlayed());
+    assertEquals(50.0, result.getWinrate());
+    assertEquals(3.0, result.getKda());
+    assertNotNull(result.getLastUpdatedAt());
+    verify(userRepository, times(1)).save(user);
+  }
+
+  @Test
+  void getLeaderboardShouldSortByWinrateThenGamesWon() {
+    User best =
+        User.builder()
+            .username("best")
+            .overwatchPlayerId("Best-1")
+            .overwatchWinrate(65.0)
+            .overwatchGamesWon(20)
+            .build();
+    User tieWinner =
+        User.builder()
+            .username("tieWinner")
+            .overwatchPlayerId("Tie-1")
+            .overwatchWinrate(55.0)
+            .overwatchGamesWon(30)
+            .build();
+    User tieLoser =
+        User.builder()
+            .username("tieLoser")
+            .overwatchPlayerId("Tie-2")
+            .overwatchWinrate(55.0)
+            .overwatchGamesWon(10)
+            .build();
+    User unattached = User.builder().username("nope").build();
+
+    when(userRepository.findAll()).thenReturn(List.of(tieLoser, unattached, tieWinner, best));
+
+    List<OverwatchProfileDto> leaderboard = overwatchService.getLeaderboard();
+
+    assertEquals(List.of("best", "tieWinner", "tieLoser"), leaderboard.stream().map(OverwatchProfileDto::getUsername).toList());
+  }
+}


### PR DESCRIPTION
## What changed

This adds the backend support for the new Fitz-Net Overwatch tracker. Authenticated users can search for an Overwatch profile through OverFast, save that profile to their Fitz-Net account, refresh/store a useful stat snapshot, and appear on a server leaderboard.

## Highlights

- Adds authenticated `/overwatch/**` endpoints for search, profile linking, current user stats, and leaderboard data.
- Proxies OverFast player search and player summary/stat calls server-side.
- Stores each user's Overwatch profile metadata and summarized stats on the Mongo user record.
- Sorts leaderboard users by `winrate`, then `gamesWon`.
- Keeps tests isolated from the live OverFast API by mocking the client/service layer.

## API contract

- `GET /overwatch/search?name=Matt`
  - Returns `[{ playerId, name, avatar, privacy, careerUrl }]`
- `PUT /overwatch/profile`
  - Body: `{ "playerId": "BattleTag-1234", "gamemode": "competitive", "platform": "pc" }`
  - `gamemode` and `platform` are optional.
- `POST /overwatch/profile`
  - Same contract as `PUT /overwatch/profile`.
- `GET /overwatch/me`
  - Returns `{ username, playerId, displayName, avatarUrl, lastUpdatedAt, gamesWon, gamesPlayed, winrate, kda, eliminations, deaths, damage, healing }`
- `GET /overwatch/leaderboard`
  - Returns the same profile DTO array for linked users.

## Screenshot

Frontend companion branch screenshot:

![Overwatch tracker UI](https://raw.githubusercontent.com/mattlol85/fitz-net-website/feature/overwatch-tracker/docs/pr-assets/overwatch-tracker.png)

## Frontend companion

Pairs with the website PR:

- https://github.com/mattlol85/fitz-net-website/pull/12

## Validation

- [x] `./gradlew.bat test`

## Notes

This keeps all OverFast integration on the API side, so the browser never needs to call OverFast directly.