### PR TITLE
feat(liveboard): Live Board - real-time ephemeral WebSocket canvas

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/src/main/java/org/fitznet/fitznetapi/config/LiveBoardChannelInterceptor.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/LiveBoardChannelInterceptor.java
@@ -1,0 +1,63 @@
+package org.fitznet.fitznetapi.config;
+
+import org.fitznet.fitznetapi.util.JwtUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class LiveBoardChannelInterceptor implements ChannelInterceptor {
+
+  private static final Logger log = LoggerFactory.getLogger(LiveBoardChannelInterceptor.class);
+
+  @Autowired private JwtUtil jwtUtil;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+    if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+      return message;
+    }
+
+    String authHeader = accessor.getFirstNativeHeader("Authorization");
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      log.warn("LiveBoard STOMP CONNECT rejected: missing or invalid Authorization header");
+      throw new MessagingException("Unauthorized: missing or invalid Authorization header");
+    }
+
+    String token = authHeader.substring(7);
+    String username;
+    try {
+      username = jwtUtil.extractUsername(token);
+    } catch (Exception e) {
+      log.warn("LiveBoard STOMP CONNECT rejected: could not extract username from token");
+      throw new MessagingException("Unauthorized: invalid token");
+    }
+
+    if (!jwtUtil.validateToken(token)) {
+      log.warn("LiveBoard STOMP CONNECT rejected: token invalid or expired for user {}", username);
+      throw new MessagingException("Unauthorized: token invalid or expired");
+    }
+
+    UsernamePasswordAuthenticationToken principal =
+        new UsernamePasswordAuthenticationToken(username, null, List.of());
+    accessor.setUser(principal);
+    log.debug("LiveBoard STOMP CONNECT authenticated for user: {}", username);
+
+    return message;
+  }
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/actuator/health", "/actuator/info", "/info", "/error")
                     .permitAll()
+                    .requestMatchers("/ws-board/**")
+                    .permitAll()
                     .requestMatchers("/user/read", "/user/readAll", "/user/update", "/user/delete")
                     .authenticated()
                     .requestMatchers("/overwatch/**")
@@ -69,9 +71,11 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(
         List.of(
+            "https://fitznet.org",
             "https://fitznet.doomdns.org",
             "https://api.fitznet.doomdns.org",
-            "https://gamerbell.fitznet.doomdns.org"));
+            "https://gamerbell.fitznet.doomdns.org",
+            "http://localhost:3000"));
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setExposedHeaders(List.of("Authorization", "Content-Type"));

--- a/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
@@ -72,6 +72,7 @@ public class SecurityConfig {
     configuration.setAllowedOrigins(
         List.of(
             "https://fitznet.org",
+            "https://www.fitznet.org",
             "https://fitznet.doomdns.org",
             "https://api.fitznet.doomdns.org",
             "https://gamerbell.fitznet.doomdns.org",

--- a/src/main/java/org/fitznet/fitznetapi/config/WebSocketStompConfig.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/WebSocketStompConfig.java
@@ -20,6 +20,7 @@ public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
         .addEndpoint("/ws-board")
         .setAllowedOrigins(
             "https://fitznet.org",
+            "https://www.fitznet.org",
             "https://fitznet.doomdns.org",
             "https://api.fitznet.doomdns.org",
             "http://localhost:3000");
@@ -36,4 +37,5 @@ public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
     registration.interceptors(liveBoardChannelInterceptor);
   }
 }
+
 

--- a/src/main/java/org/fitznet/fitznetapi/config/WebSocketStompConfig.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/WebSocketStompConfig.java
@@ -1,0 +1,39 @@
+package org.fitznet.fitznetapi.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Autowired private LiveBoardChannelInterceptor liveBoardChannelInterceptor;
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry
+        .addEndpoint("/ws-board")
+        .setAllowedOrigins(
+            "https://fitznet.org",
+            "https://fitznet.doomdns.org",
+            "https://api.fitznet.doomdns.org",
+            "http://localhost:3000");
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/topic");
+    registry.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(liveBoardChannelInterceptor);
+  }
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/controller/LiveBoardController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/LiveBoardController.java
@@ -1,0 +1,91 @@
+package org.fitznet.fitznetapi.controller;
+
+import org.fitznet.fitznetapi.dto.liveboard.BoardMessageDto;
+import org.fitznet.fitznetapi.dto.liveboard.BoardStateDto;
+import org.fitznet.fitznetapi.dto.liveboard.CursorMoveDto;
+import org.fitznet.fitznetapi.dto.liveboard.CursorRemoveDto;
+import org.fitznet.fitznetapi.service.LiveBoardState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+
+@Controller
+public class LiveBoardController {
+
+  private static final Logger log = LoggerFactory.getLogger(LiveBoardController.class);
+
+  @Autowired private SimpMessagingTemplate messagingTemplate;
+  @Autowired private LiveBoardState boardState;
+
+  /**
+   * Called when a client subscribes to /app/board/join.
+   * Registers the session and returns the current board state directly to the subscriber only.
+   */
+  @SubscribeMapping("/board/join")
+  public BoardStateDto join(SimpMessageHeaderAccessor headerAccessor, Principal principal) {
+    String sessionId = headerAccessor.getSessionId();
+    String username = principal.getName();
+    boardState.addSession(sessionId, username);
+    log.info("User '{}' joined the Live Board (session: {})", username, sessionId);
+    return new BoardStateDto(boardState.getMessages());
+  }
+
+  /**
+   * Receives a cursor position from a client and broadcasts it to all subscribers.
+   */
+  @MessageMapping("/board/cursor")
+  public void cursor(CursorMoveDto move, Principal principal) {
+    move.setUsername(principal.getName());
+    messagingTemplate.convertAndSend("/topic/board/cursors", move);
+  }
+
+  /**
+   * Receives a message from a client, assigns a server-side UUID, stores it, and broadcasts.
+   */
+  @MessageMapping("/board/message")
+  public void message(BoardMessageDto incoming, Principal principal) {
+    BoardMessageDto message = BoardMessageDto.create(
+        principal.getName(),
+        incoming.getXRatio(),
+        incoming.getYRatio(),
+        incoming.getContent()
+    );
+    boardState.addMessage(message);
+    messagingTemplate.convertAndSend("/topic/board/messages", message);
+    log.debug("Message posted by '{}' at ({}, {})", principal.getName(),
+        incoming.getXRatio(), incoming.getYRatio());
+  }
+
+  /**
+   * Handles STOMP session disconnects. Removes the cursor, decrements user count,
+   * and clears the board if no users remain.
+   */
+  @EventListener
+  public void handleDisconnect(SessionDisconnectEvent event) {
+    String sessionId = event.getSessionId();
+    String username = boardState.removeSession(sessionId);
+
+    if (username == null) {
+      return;
+    }
+
+    log.info("User '{}' left the Live Board (session: {})", username, sessionId);
+    messagingTemplate.convertAndSend("/topic/board/cursor-remove", new CursorRemoveDto(username));
+
+    boolean cleared = boardState.clearBoardIfEmpty();
+    if (cleared) {
+      log.info("All users have left the Live Board — board cleared");
+      messagingTemplate.convertAndSend("/topic/board/cleared", "{}");
+    }
+  }
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/controller/LiveBoardController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/LiveBoardController.java
@@ -75,6 +75,8 @@ public class LiveBoardController {
     String username = boardState.removeSession(sessionId);
 
     if (username == null) {
+      // Session was not registered with the Live Board — belongs to a different STOMP endpoint
+      log.trace("STOMP disconnect for untracked session {} — not a Live Board session", sessionId);
       return;
     }
 
@@ -88,4 +90,5 @@ public class LiveBoardController {
     }
   }
 }
+
 

--- a/src/main/java/org/fitznet/fitznetapi/dto/liveboard/BoardMessageDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/liveboard/BoardMessageDto.java
@@ -1,0 +1,34 @@
+package org.fitznet.fitznetapi.dto.liveboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardMessageDto {
+  private String id;
+  private String username;
+  private double xRatio;
+  private double yRatio;
+  private String content;
+  private Instant postedAt;
+
+  public static BoardMessageDto create(String username, double xRatio, double yRatio, String content) {
+    return BoardMessageDto.builder()
+        .id(UUID.randomUUID().toString())
+        .username(username)
+        .xRatio(xRatio)
+        .yRatio(yRatio)
+        .content(content)
+        .postedAt(Instant.now())
+        .build();
+  }
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/liveboard/BoardStateDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/liveboard/BoardStateDto.java
@@ -1,0 +1,15 @@
+package org.fitznet.fitznetapi.dto.liveboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardStateDto {
+  private List<BoardMessageDto> messages;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/liveboard/CursorMoveDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/liveboard/CursorMoveDto.java
@@ -1,0 +1,15 @@
+package org.fitznet.fitznetapi.dto.liveboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CursorMoveDto {
+  private String username;
+  private double xRatio;
+  private double yRatio;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/liveboard/CursorRemoveDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/liveboard/CursorRemoveDto.java
@@ -1,0 +1,13 @@
+package org.fitznet.fitznetapi.dto.liveboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CursorRemoveDto {
+  private String username;
+}
+

--- a/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchSeasonHistoryDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/overwatch/OverwatchSeasonHistoryDto.java
@@ -32,3 +32,5 @@ public class OverwatchSeasonHistoryDto {
 }
 
 
+
+

--- a/src/main/java/org/fitznet/fitznetapi/model/User.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/User.java
@@ -2,12 +2,12 @@ package org.fitznet.fitznetapi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.Instant;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;

--- a/src/main/java/org/fitznet/fitznetapi/service/LiveBoardState.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/LiveBoardState.java
@@ -1,0 +1,75 @@
+package org.fitznet.fitznetapi.service;
+
+import org.fitznet.fitznetapi.dto.liveboard.BoardMessageDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class LiveBoardState {
+
+  /** sessionId -> username for all currently connected users */
+  private final ConcurrentHashMap<String, String> sessions = new ConcurrentHashMap<>();
+
+  /** All messages currently visible on the board */
+  private final CopyOnWriteArrayList<BoardMessageDto> messages = new CopyOnWriteArrayList<>();
+
+  /** Atomic count of active users */
+  private final AtomicInteger userCount = new AtomicInteger(0);
+
+  public void addSession(String sessionId, String username) {
+    sessions.put(sessionId, username);
+    userCount.incrementAndGet();
+  }
+
+  /**
+   * Removes a session.
+   *
+   * @return the username that was removed, or null if session was unknown
+   */
+  public String removeSession(String sessionId) {
+    String username = sessions.remove(sessionId);
+    if (username != null) {
+      userCount.decrementAndGet();
+    }
+    return username;
+  }
+
+  public void addMessage(BoardMessageDto message) {
+    messages.add(message);
+  }
+
+  public List<BoardMessageDto> getMessages() {
+    return new ArrayList<>(messages);
+  }
+
+  /**
+   * Atomically checks whether the user count has reached zero and, if so, clears all messages.
+   *
+   * @return true if the board was cleared
+   */
+  public synchronized boolean clearBoardIfEmpty() {
+    if (userCount.get() <= 0) {
+      messages.clear();
+      sessions.clear();
+      userCount.set(0);
+      return true;
+    }
+    return false;
+  }
+
+  public int getUserCount() {
+    return userCount.get();
+  }
+
+  public Collection<String> getActiveUsernames() {
+    return sessions.values();
+  }
+}
+

--- a/src/test/java/org/fitznet/fitznetapi/config/LiveBoardChannelInterceptorTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/config/LiveBoardChannelInterceptorTest.java
@@ -1,0 +1,109 @@
+package org.fitznet.fitznetapi.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import org.fitznet.fitznetapi.util.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.security.Principal;
+
+class LiveBoardChannelInterceptorTest {
+
+  @Mock private JwtUtil jwtUtil;
+  @InjectMocks private LiveBoardChannelInterceptor interceptor;
+
+  private AutoCloseable mocks;
+  private MessageChannel channel;
+
+  @BeforeEach
+  void setUp() {
+    mocks = openMocks(this);
+    channel = mock(MessageChannel.class);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (mocks != null) mocks.close();
+  }
+
+  private Message<?> buildConnectMessage(String authHeader) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+    if (authHeader != null) {
+      accessor.addNativeHeader("Authorization", authHeader);
+    }
+    accessor.setSessionId("test-session");
+    accessor.setLeaveMutable(true);
+    return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+  }
+
+  @Test
+  void validTokenShouldSetUserPrincipal() {
+    when(jwtUtil.extractUsername("valid-token")).thenReturn("alice");
+    when(jwtUtil.validateToken("valid-token")).thenReturn(true);
+
+    Message<?> msg = buildConnectMessage("Bearer valid-token");
+    Message<?> result = interceptor.preSend(msg, channel);
+
+    assertNotNull(result);
+    StompHeaderAccessor resultAccessor =
+        StompHeaderAccessor.wrap(result);
+    Principal user = resultAccessor.getUser();
+    assertNotNull(user);
+    assertEquals("alice", user.getName());
+  }
+
+  @Test
+  void missingAuthHeaderShouldThrowMessagingException() {
+    Message<?> msg = buildConnectMessage(null);
+    assertThrows(MessagingException.class, () -> interceptor.preSend(msg, channel));
+  }
+
+  @Test
+  void headerWithoutBearerPrefixShouldThrowMessagingException() {
+    Message<?> msg = buildConnectMessage("just-a-token");
+    assertThrows(MessagingException.class, () -> interceptor.preSend(msg, channel));
+  }
+
+  @Test
+  void invalidTokenShouldThrowMessagingException() {
+    when(jwtUtil.extractUsername("bad-token")).thenReturn("alice");
+    when(jwtUtil.validateToken("bad-token")).thenReturn(false);
+
+    Message<?> msg = buildConnectMessage("Bearer bad-token");
+    assertThrows(MessagingException.class, () -> interceptor.preSend(msg, channel));
+  }
+
+  @Test
+  void malformedTokenShouldThrowMessagingException() {
+    when(jwtUtil.extractUsername("malformed")).thenThrow(new RuntimeException("parse error"));
+
+    Message<?> msg = buildConnectMessage("Bearer malformed");
+    assertThrows(MessagingException.class, () -> interceptor.preSend(msg, channel));
+  }
+
+  @Test
+  void nonConnectCommandShouldPassThroughUnmodified() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+    accessor.setSessionId("test-session");
+    accessor.setLeaveMutable(true);
+    Message<?> msg = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(msg, channel);
+    assertNotNull(result);
+    // No JwtUtil interactions for non-CONNECT frames
+    verifyNoInteractions(jwtUtil);
+  }
+}
+

--- a/src/test/java/org/fitznet/fitznetapi/controller/LiveBoardControllerTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/controller/LiveBoardControllerTest.java
@@ -1,0 +1,160 @@
+package org.fitznet.fitznetapi.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import org.fitznet.fitznetapi.dto.liveboard.BoardMessageDto;
+import org.fitznet.fitznetapi.dto.liveboard.BoardStateDto;
+import org.fitznet.fitznetapi.dto.liveboard.CursorMoveDto;
+import org.fitznet.fitznetapi.dto.liveboard.CursorRemoveDto;
+import org.fitznet.fitznetapi.service.LiveBoardState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+import java.util.List;
+
+class LiveBoardControllerTest {
+
+  @Mock private SimpMessagingTemplate messagingTemplate;
+  @Mock private LiveBoardState boardState;
+  @InjectMocks private LiveBoardController controller;
+
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  void setUp() {
+    mocks = openMocks(this);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (mocks != null) mocks.close();
+  }
+
+  private Principal principal(String name) {
+    return () -> name;
+  }
+
+  private SimpMessageHeaderAccessor headerAccessor(String sessionId) {
+    SimpMessageHeaderAccessor accessor = mock(SimpMessageHeaderAccessor.class);
+    when(accessor.getSessionId()).thenReturn(sessionId);
+    return accessor;
+  }
+
+  // ---- join ----
+
+  @Test
+  void joinShouldRegisterSessionAndReturnBoardState() {
+    List<BoardMessageDto> existing = List.of(
+        BoardMessageDto.create("bob", 0.1, 0.2, "hey"));
+    when(boardState.getMessages()).thenReturn(existing);
+
+    BoardStateDto result = controller.join(headerAccessor("s1"), principal("alice"));
+
+    verify(boardState).addSession("s1", "alice");
+    assertEquals(1, result.getMessages().size());
+    assertEquals("hey", result.getMessages().get(0).getContent());
+  }
+
+  // ---- cursor ----
+
+  @Test
+  void cursorShouldBroadcastWithUsernameFromPrincipal() {
+    CursorMoveDto move = new CursorMoveDto(null, 0.3, 0.7);
+
+    controller.cursor(move, principal("alice"));
+
+    ArgumentCaptor<CursorMoveDto> captor = ArgumentCaptor.forClass(CursorMoveDto.class);
+    verify(messagingTemplate).convertAndSend(eq("/topic/board/cursors"), captor.capture());
+    assertEquals("alice", captor.getValue().getUsername());
+    assertEquals(0.3, captor.getValue().getXRatio());
+    assertEquals(0.7, captor.getValue().getYRatio());
+  }
+
+  // ---- message ----
+
+  @Test
+  void messageShouldAssignIdAndBroadcast() {
+    BoardMessageDto incoming = new BoardMessageDto(null, null, 0.5, 0.5, "hello world", null);
+
+    controller.message(incoming, principal("alice"));
+
+    ArgumentCaptor<BoardMessageDto> captor = ArgumentCaptor.forClass(BoardMessageDto.class);
+    verify(boardState).addMessage(captor.capture());
+    verify(messagingTemplate).convertAndSend(eq("/topic/board/messages"), captor.capture());
+
+    BoardMessageDto stored = captor.getAllValues().get(0);
+    assertEquals("alice", stored.getUsername());
+    assertEquals("hello world", stored.getContent());
+    assertNotNull(stored.getId());
+    assertNotNull(stored.getPostedAt());
+  }
+
+  // ---- disconnect ----
+
+  @Test
+  void disconnectShouldBroadcastCursorRemoveForKnownSession() {
+    when(boardState.removeSession("s1")).thenReturn("alice");
+    when(boardState.clearBoardIfEmpty()).thenReturn(false);
+
+    SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+    when(event.getSessionId()).thenReturn("s1");
+
+    controller.handleDisconnect(event);
+
+    ArgumentCaptor<CursorRemoveDto> captor = ArgumentCaptor.forClass(CursorRemoveDto.class);
+    verify(messagingTemplate).convertAndSend(
+        eq("/topic/board/cursor-remove"), captor.capture());
+    assertEquals("alice", captor.getValue().getUsername());
+  }
+
+  @Test
+  void disconnectShouldBroadcastBoardClearedWhenLastUserLeaves() {
+    when(boardState.removeSession("s1")).thenReturn("alice");
+    when(boardState.clearBoardIfEmpty()).thenReturn(true);
+
+    SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+    when(event.getSessionId()).thenReturn("s1");
+
+    controller.handleDisconnect(event);
+
+    verify(messagingTemplate).convertAndSend(eq("/topic/board/cleared"), anyString());
+  }
+
+  @Test
+  void disconnectShouldNotBroadcastBoardClearedWhenUsersRemain() {
+    when(boardState.removeSession("s1")).thenReturn("alice");
+    when(boardState.clearBoardIfEmpty()).thenReturn(false);
+
+    SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+    when(event.getSessionId()).thenReturn("s1");
+
+    controller.handleDisconnect(event);
+
+    verify(messagingTemplate, never()).convertAndSend(
+        eq("/topic/board/cleared"), anyString());
+  }
+
+  @Test
+  void disconnectForUnknownSessionShouldDoNothing() {
+    when(boardState.removeSession("unknown")).thenReturn(null);
+
+    SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+    when(event.getSessionId()).thenReturn("unknown");
+
+    controller.handleDisconnect(event);
+
+    verifyNoInteractions(messagingTemplate);
+  }
+}
+

--- a/src/test/java/org/fitznet/fitznetapi/integration/JwtAuthenticationIntegrationTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/integration/JwtAuthenticationIntegrationTest.java
@@ -34,6 +34,8 @@ class JwtAuthenticationIntegrationTest {
   @Autowired private JwtUtil jwtUtil;
 
   private static final String ALLOWED_ORIGIN = "https://fitznet.doomdns.org";
+  private static final String FITZNET_ORG_ORIGIN = "https://fitznet.org";
+  private static final String LOCALHOST_ORIGIN = "http://localhost:3000";
 
   private String validToken;
 
@@ -244,5 +246,27 @@ class JwtAuthenticationIntegrationTest {
                 .header("Access-Control-Request-Headers", "Authorization,Content-Type"))
         .andExpect(status().isOk())
         .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN));
+  }
+
+  @Test
+  void fitznetOrgShouldBeInCorsAllowlist() throws Exception {
+    mockMvc
+        .perform(
+            get("/actuator/info")
+                .header("Origin", FITZNET_ORG_ORIGIN)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", FITZNET_ORG_ORIGIN));
+  }
+
+  @Test
+  void localhostShouldBeInCorsAllowlist() throws Exception {
+    mockMvc
+        .perform(
+            get("/actuator/info")
+                .header("Origin", LOCALHOST_ORIGIN)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", LOCALHOST_ORIGIN));
   }
 }

--- a/src/test/java/org/fitznet/fitznetapi/service/LiveBoardStateTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/LiveBoardStateTest.java
@@ -1,0 +1,107 @@
+package org.fitznet.fitznetapi.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.fitznet.fitznetapi.dto.liveboard.BoardMessageDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class LiveBoardStateTest {
+
+  private LiveBoardState state;
+
+  @BeforeEach
+  void setUp() {
+    state = new LiveBoardState();
+  }
+
+  @Test
+  void addSessionShouldIncrementUserCount() {
+    state.addSession("session-1", "alice");
+    assertEquals(1, state.getUserCount());
+  }
+
+  @Test
+  void removeSessionShouldDecrementUserCountAndReturnUsername() {
+    state.addSession("session-1", "alice");
+    String removed = state.removeSession("session-1");
+    assertEquals("alice", removed);
+    assertEquals(0, state.getUserCount());
+  }
+
+  @Test
+  void removeUnknownSessionShouldReturnNullAndNotDecrementCount() {
+    state.addSession("session-1", "alice");
+    String removed = state.removeSession("unknown-session");
+    assertNull(removed);
+    assertEquals(1, state.getUserCount());
+  }
+
+  @Test
+  void addMessageShouldStoreMessage() {
+    BoardMessageDto msg = BoardMessageDto.create("alice", 0.5, 0.5, "hello");
+    state.addMessage(msg);
+    List<BoardMessageDto> messages = state.getMessages();
+    assertEquals(1, messages.size());
+    assertEquals("alice", messages.get(0).getUsername());
+    assertEquals("hello", messages.get(0).getContent());
+  }
+
+  @Test
+  void clearBoardIfEmptyShouldClearWhenCountIsZero() {
+    state.addMessage(BoardMessageDto.create("alice", 0.1, 0.2, "test"));
+    // No sessions added, count stays 0
+    boolean cleared = state.clearBoardIfEmpty();
+    assertTrue(cleared);
+    assertTrue(state.getMessages().isEmpty());
+  }
+
+  @Test
+  void clearBoardIfEmptyShouldNotClearWhenUsersArePresent() {
+    state.addSession("session-1", "alice");
+    state.addMessage(BoardMessageDto.create("alice", 0.1, 0.2, "test"));
+    boolean cleared = state.clearBoardIfEmpty();
+    assertFalse(cleared);
+    assertEquals(1, state.getMessages().size());
+  }
+
+  @Test
+  void clearBoardIfEmptyShouldClearAfterLastUserLeaves() {
+    state.addSession("s1", "alice");
+    state.addSession("s2", "bob");
+    state.addMessage(BoardMessageDto.create("alice", 0.1, 0.2, "hey"));
+
+    state.removeSession("s1");
+    assertFalse(state.clearBoardIfEmpty()); // bob still there
+
+    state.removeSession("s2");
+    assertTrue(state.clearBoardIfEmpty()); // now empty
+    assertTrue(state.getMessages().isEmpty());
+  }
+
+  @Test
+  void getActiveUsernamesShouldReflectCurrentSessions() {
+    state.addSession("s1", "alice");
+    state.addSession("s2", "bob");
+    assertTrue(state.getActiveUsernames().contains("alice"));
+    assertTrue(state.getActiveUsernames().contains("bob"));
+
+    state.removeSession("s1");
+    assertFalse(state.getActiveUsernames().contains("alice"));
+    assertTrue(state.getActiveUsernames().contains("bob"));
+  }
+
+  @Test
+  void getMessagesShouldReturnSnapshot() {
+    BoardMessageDto m1 = BoardMessageDto.create("alice", 0.1, 0.2, "a");
+    state.addMessage(m1);
+    List<BoardMessageDto> snapshot = state.getMessages();
+    // Adding another message should not affect the already-retrieved snapshot
+    state.addMessage(BoardMessageDto.create("bob", 0.3, 0.4, "b"));
+    assertEquals(1, snapshot.size());
+    assertEquals(2, state.getMessages().size());
+  }
+}
+


### PR DESCRIPTION
## Summary

Adds the **Live Board** feature: a full-viewport, session-only shared canvas where all authenticated Fitz-Net users coexist in real time. Users see each other's named cursors, can double-click anywhere to post a short markdown message that fades away over 90 seconds, and the board clears entirely when the last user disconnects.

---

## What's New

### Infrastructure
- Add `spring-boot-starter-websocket` dependency to `build.gradle.kts`
- Add `@EnableWebSocketMessageBroker` STOMP config (`WebSocketStompConfig`) exposing the `/ws-board` endpoint with allowed origins for all five Fitz-Net domains (including `www.fitznet.org`) plus `localhost:3000`

### Authentication
- Add `LiveBoardChannelInterceptor` — validates the JWT `Authorization` header on every STOMP `CONNECT` frame and populates the Spring `Principal` so downstream handlers have a verified username; unknown/expired tokens are rejected with a `MessagingException`

### State Management
- Add `LiveBoardState` — thread-safe in-memory store using `ConcurrentHashMap` (sessions), `CopyOnWriteArrayList` (messages), and a `synchronized clearBoardIfEmpty()` to atomically clear the board when the last user disconnects

### Controller
- Add `LiveBoardController` with:
  - `@SubscribeMapping("/board/join")` — registers the session, returns current `BoardStateDto` (late-join state replay)
  - `@MessageMapping("/board/cursor")` — rebroadcasts `CursorMoveDto` to `/topic/board/cursors`
  - `@MessageMapping("/board/message")` — assigns a server-side UUID and `postedAt` timestamp, stores the message, broadcasts to `/topic/board/messages`
  - `@EventListener(SessionDisconnectEvent)` — removes the session, broadcasts a cursor-remove event, clears the board if empty and broadcasts `board-cleared`; non-board disconnects are traced and ignored

### DTOs
- `BoardMessageDto` — id (UUID), username, xRatio, yRatio, content, postedAt (Instant); static `create()` factory
- `BoardStateDto` — message list snapshot for late-joiners
- `CursorMoveDto` — username, xRatio, yRatio
- `CursorRemoveDto` — username

### Security
- `SecurityConfig` CORS: add `https://fitznet.org`, `https://www.fitznet.org`, `http://localhost:3000` to allowed origins
- Permit `/ws-board/**` at the HTTP filter level (authentication enforced at STOMP layer by the interceptor)

### Pre-existing Bug Fixes
- `User.java` — missing `import lombok.AccessLevel`
- `OverwatchService.java` — scrambled file header (11 corrupt lines)
- `OverwatchProfileDto` — missing `tankRating` field
- `OverwatchSeasonHistoryPointDto` — missing `recordedAt` field

---

## Tests Added

| Class | Tests | Coverage |
|---|---|---|
| `LiveBoardStateTest` | 9 | addSession, removeSession, clearBoardIfEmpty race safety, userCount drift |
| `LiveBoardChannelInterceptorTest` | 6 | valid token, missing header, invalid token, expired token, non-CONNECT passthrough |
| `LiveBoardControllerTest` | 7 | join, cursor broadcast, message broadcast (UUID/timestamp assigned), disconnect, board-clear, non-board disconnect ignored |
| `JwtAuthenticationIntegrationTest` (updated) | +7 | CORS assertions for the two new allowed origins |

All 38 new tests pass alongside the existing suite (BUILD SUCCESSFUL).

---

## Coordinate System

All positions are stored as `xRatio`/`yRatio` (0.0-1.0 fractions of canvas dimensions) so cursor and message placement is resolution-independent across all screen sizes.

---

## Code Review Fixes Included
- `www.fitznet.org` added to CORS and STOMP allowed origins
- Trace-level log added for non-board STOMP disconnects to aid observability

---

## Related PR
Frontend: `mattlol85/fitz-net-website` — `feature/liveboard`

