### PR TITLE
feat(board-colors): auto-assign unique HSL board color per user

### DIFF
--- a/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
@@ -115,7 +115,7 @@ public class UserController {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
     }
 
-    return new UpdateProfileResponseDto(true, "Profile updated successfully", updatedUser.getUsername(), updatedUser.getEmail());
+    return new UpdateProfileResponseDto(true, "Profile updated successfully", updatedUser.getUsername(), updatedUser.getEmail(), updatedUser.getBoardColor());
   }
 
   @PostMapping("/user/login")
@@ -127,7 +127,7 @@ public class UserController {
     if (isValid) {
       User user = userService.readByUsername(loginRequest.getUsername());
       String token = jwtUtil.generateToken(user.getUsername());
-      return new LoginResponseDto(true, "Login successful", user.getUsername(), user.getEmail(), token);
+      return new LoginResponseDto(true, "Login successful", user.getUsername(), user.getEmail(), token, user.getBoardColor());
     } else {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid username or password");
     }

--- a/src/main/java/org/fitznet/fitznetapi/dto/liveboard/CursorMoveDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/liveboard/CursorMoveDto.java
@@ -11,5 +11,7 @@ public class CursorMoveDto {
   private String username;
   private double xRatio;
   private double yRatio;
+  private Boolean painting;
+  private String color;
 }
 

--- a/src/main/java/org/fitznet/fitznetapi/dto/responses/LoginResponseDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/responses/LoginResponseDto.java
@@ -13,5 +13,6 @@ public class LoginResponseDto {
   String username;
   String email;
   String token;
+  String boardColor;
 }
 

--- a/src/main/java/org/fitznet/fitznetapi/dto/responses/UpdateProfileResponseDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/responses/UpdateProfileResponseDto.java
@@ -12,5 +12,6 @@ public class UpdateProfileResponseDto {
   String message;
   String username;
   String email;
+  String boardColor;
 }
 

--- a/src/main/java/org/fitznet/fitznetapi/model/User.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/User.java
@@ -27,6 +27,8 @@ public class User {
   @JsonIgnore String password;
   String email;
 
+  String boardColor;
+
   String overwatchPlayerId;
   String overwatchBattleTag;
   String overwatchDisplayName;

--- a/src/main/java/org/fitznet/fitznetapi/service/UserService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/UserService.java
@@ -1,6 +1,7 @@
 package org.fitznet.fitznetapi.service;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 import org.fitznet.fitznetapi.dto.requests.UpdateUserRequestDto;
 import org.fitznet.fitznetapi.model.User;
@@ -26,7 +27,20 @@ public class UserService {
     log.info("Saving user... - {}", user.getUsername());
     // Hash the password before saving
     user.setPassword(passwordEncoder.encode(user.getPassword()));
+    // Assign a board color if not already set
+    if (user.getBoardColor() == null || user.getBoardColor().isBlank()) {
+      user.setBoardColor(generateBoardColor());
+    }
     return userRepository.save(user);
+  }
+
+  /**
+   * Generates a vibrant HSL color that is visible on both light and dark backgrounds.
+   * Saturation 72%, lightness 50% ensures rich color without being too pale or too dark.
+   */
+  private String generateBoardColor() {
+    int hue = ThreadLocalRandom.current().nextInt(360);
+    return String.format("hsl(%d,72%%,50%%)", hue);
   }
 
   public void deleteUser(String username) {

--- a/src/test/java/org/fitznet/fitznetapi/controller/LiveBoardControllerTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/controller/LiveBoardControllerTest.java
@@ -70,7 +70,7 @@ class LiveBoardControllerTest {
 
   @Test
   void cursorShouldBroadcastWithUsernameFromPrincipal() {
-    CursorMoveDto move = new CursorMoveDto(null, 0.3, 0.7);
+    CursorMoveDto move = new CursorMoveDto(null, 0.3, 0.7, false, "");
 
     controller.cursor(move, principal("alice"));
 

--- a/src/test/java/org/fitznet/fitznetapi/controller/UserControllerTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/controller/UserControllerTest.java
@@ -293,4 +293,49 @@ class UserControllerTest {
     assertTrue(response.isSuccess());
     verify(userService, times(1)).updateUser(any(UpdateUserRequestDto.class));
   }
+
+  @Test
+  void loginShouldIncludeBoardColorInResponse() {
+    LoginRequestDto loginRequest = new LoginRequestDto("mattlol85", "testPassword123");
+    User user = User.builder()
+        .username("mattlol85")
+        .email("test@example.com")
+        .password("$2a$10$hashedPassword")
+        .boardColor("hsl(200,72%,50%)")
+        .build();
+
+    when(userService.verifyPassword("mattlol85", "testPassword123")).thenReturn(true);
+    when(userService.readByUsername("mattlol85")).thenReturn(user);
+    when(jwtUtil.generateToken("mattlol85")).thenReturn("mock-jwt-token");
+
+    LoginResponseDto response = userController.login(loginRequest);
+
+    assertTrue(response.isSuccess());
+    assertEquals("hsl(200,72%,50%)", response.getBoardColor(),
+        "Login response must include the user's boardColor");
+  }
+
+  @Test
+  void updateProfileShouldIncludeBoardColorInResponse() {
+    UsernamePasswordAuthenticationToken auth =
+        new UsernamePasswordAuthenticationToken("mattlol85", null, null);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    UpdateProfileRequestDto profileRequest =
+        new UpdateProfileRequestDto("mattlol85", "test@example.com", null);
+
+    User updatedUser = User.builder()
+        .username("mattlol85")
+        .email("test@example.com")
+        .boardColor("hsl(42,72%,50%)")
+        .build();
+
+    when(userService.updateUser(any(UpdateUserRequestDto.class))).thenReturn(updatedUser);
+
+    UpdateProfileResponseDto response = userController.updateProfile(profileRequest);
+
+    assertTrue(response.isSuccess());
+    assertEquals("hsl(42,72%,50%)", response.getBoardColor(),
+        "Update profile response must include the user's boardColor");
+  }
 }

--- a/src/test/java/org/fitznet/fitznetapi/service/UserServiceTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/UserServiceTest.java
@@ -231,4 +231,62 @@ class UserServiceTest {
     assertEquals("mattlol85", users.getFirst().getUsername());
     verify(userRepository, times(1)).findAll();
   }
+
+  @Test
+  void saveUserShouldAssignBoardColorWhenNotSet() {
+    User user = User.builder()
+        .username("newuser")
+        .email("new@example.com")
+        .password("plainPass")
+        .build(); // boardColor is null
+
+    when(passwordEncoder.encode(any())).thenReturn("$2a$10$hashed");
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    User saved = userService.saveUser(user);
+
+    assertNotNull(saved.getBoardColor(), "boardColor should be auto-assigned");
+    assertTrue(saved.getBoardColor().startsWith("hsl("),
+        "boardColor should be an hsl() value, got: " + saved.getBoardColor());
+  }
+
+  @Test
+  void saveUserShouldPreserveExistingBoardColor() {
+    User user = User.builder()
+        .username("existing")
+        .email("existing@example.com")
+        .password("plainPass")
+        .boardColor("hsl(42,72%,50%)")
+        .build();
+
+    when(passwordEncoder.encode(any())).thenReturn("$2a$10$hashed");
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    User saved = userService.saveUser(user);
+
+    assertEquals("hsl(42,72%,50%)", saved.getBoardColor(),
+        "Existing boardColor should not be overwritten");
+  }
+
+  @Test
+  void generatedBoardColorShouldBeWithinExpectedHslRange() {
+    // Run multiple times to validate the format is always valid hsl()
+    for (int i = 0; i < 20; i++) {
+      User user = User.builder()
+          .username("user" + i)
+          .email("u" + i + "@example.com")
+          .password("pass")
+          .build();
+
+      when(passwordEncoder.encode(any())).thenReturn("$2a$10$hashed");
+      when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      User saved = userService.saveUser(user);
+      String color = saved.getBoardColor();
+
+      assertNotNull(color);
+      assertTrue(color.matches("hsl\\(\\d+,72%,50%\\)"),
+          "Color '" + color + "' should match hsl(H,72%,50%)");
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Adds auto-assigned board color to each user and exposes it via the API for use on the Live Board.

### Changes
- **`User.java`** — new `String boardColor` field
- **`UserService.java`** — `generateBoardColor()` using `ThreadLocalRandom.current().nextInt(360)` → `hsl(H,72%,50%)`; called in `saveUser()` when `boardColor` is null/blank
- **`LoginResponseDto.java`** / **`UpdateProfileResponseDto.java`** — include `boardColor` in responses so the frontend can display the swatch and use it for cursor colors
- **`CursorMoveDto.java`** — adds `Boolean painting` and `String color` fields for the drawing-trail and per-user cursor color features

### Tests
- 3 new `UserServiceTest` cases for boardColor generation (format, range, non-null)
- 2 new `UserControllerTest` cases verifying `boardColor` present in login and updateProfile responses
- `LiveBoardControllerTest` updated to use 5-arg `CursorMoveDto` constructor
