### PR TITLE
fix: UserResponseDto for user endpoints + README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,370 @@
-# Getting Started
+# Fitz-Net API
 
-### Reference Documentation
+Backend REST API for the Fitz-Net platform — user authentication, a real-time shared LiveBoard canvas, and an Overwatch 2 player tracker backed by the [OverFast API](https://overfast-api.tekrop.fr).
 
-For further reference, please consider the following sections:
+**Stack:** Java 21 · Spring Boot 3.4 · MongoDB · Spring Security (JWT) · Spring WebSocket (STOMP) · Gradle
 
-* [Official Gradle documentation](https://docs.gradle.org)
-* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/docs/3.1.2/gradle-plugin/reference/html/)
-* [Create an OCI image](https://docs.spring.io/spring-boot/docs/3.1.2/gradle-plugin/reference/html/#build-image)
-* [Spring Web](https://docs.spring.io/spring-boot/docs/3.1.2/reference/htmlsingle/index.html#web)
-* [Spring Boot DevTools](https://docs.spring.io/spring-boot/docs/3.1.2/reference/htmlsingle/index.html#using.devtools)
-* [Rest Repositories](https://docs.spring.io/spring-boot/docs/3.1.2/reference/htmlsingle/index.html#howto.data-access.exposing-spring-data-repositories-as-rest)
-* [Spring Reactive Web](https://docs.spring.io/spring-boot/docs/3.1.2/reference/htmlsingle/index.html#web.reactive)
-* [Spring Data MongoDB](https://docs.spring.io/spring-boot/docs/3.1.2/reference/htmlsingle/index.html#data.nosql.mongodb)
+---
 
-### Guides
+## Table of Contents
 
-The following guides illustrate how to use some features concretely:
+- [Quick Start](#quick-start)
+- [Environment Variables](#environment-variables)
+- [Running Locally](#running-locally)
+- [Docker](#docker)
+- [API Reference](#api-reference)
+  - [Authentication](#authentication)
+  - [User](#user-endpoints)
+  - [Overwatch](#overwatch-endpoints)
+  - [LiveBoard (WebSocket)](#liveboard-websocket)
+  - [Encryption](#encryption-endpoints)
+  - [Actuator](#actuator-endpoints)
+- [Data Model](#data-model)
+- [Overwatch Refresh Cron](#overwatch-refresh-cron)
+- [CI / CD](#ci--cd)
 
-* [Building a RESTful Web Service](https://spring.io/guides/gs/rest-service/)
-* [Serving Web Content with Spring MVC](https://spring.io/guides/gs/serving-web-content/)
-* [Building REST services with Spring](https://spring.io/guides/tutorials/rest/)
-* [Accessing JPA Data with REST](https://spring.io/guides/gs/accessing-data-rest/)
-* [Accessing Neo4j Data with REST](https://spring.io/guides/gs/accessing-neo4j-data-rest/)
-* [Accessing MongoDB Data with REST](https://spring.io/guides/gs/accessing-mongodb-data-rest/)
-* [Building a Reactive RESTful Web Service](https://spring.io/guides/gs/reactive-rest-service/)
-* [Accessing Data with MongoDB](https://spring.io/guides/gs/accessing-data-mongodb/)
+---
 
-### Additional Links
+## Quick Start
 
-These additional references should also help you:
+```bash
+# Prerequisites: Java 21, MongoDB
 
-* [Gradle Build Scans – insights for your project's build](https://scans.gradle.com#gradle)
+git clone https://github.com/mattlol85/fitz-net-api.git
+cd fitz-net-api
 
+export JWT_SECRET=your-secret-here
+export MONGO_HOST=localhost
+
+./gradlew bootRun
+# API available at http://localhost:8080
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `JWT_SECRET` | Yes (prod) | `myDefaultSecretKey...` | HS256 signing secret for JWT tokens |
+| `ENCRYPTION_KEY` | No | *(empty)* | AES key for the `/encrypt`/`/decrypt` endpoints |
+| `MONGO_HOST` | No | `localhost` | MongoDB host |
+| `MONGO_PORT` | No | `27017` | MongoDB port |
+| `MONGO_DATABASE` | No | `test` | MongoDB database name (`fitznet` in prod) |
+| `SPRING_PROFILES_ACTIVE` | No | *(default)* | Set to `prod` in production |
+
+> **Note:** Never commit a real `JWT_SECRET` or `ENCRYPTION_KEY`. The defaults are for local development only.
+
+---
+
+## Running Locally
+
+```bash
+# Run tests (uses embedded MongoDB — no local Mongo needed for tests)
+./gradlew test
+
+# Build a runnable JAR
+./gradlew bootJar
+
+# Run the JAR directly
+java -jar build/libs/fitz-net-api-*.jar
+```
+
+The server starts on port `8080` by default.
+
+---
+
+## Docker
+
+Images are published to Docker Hub automatically on each release.
+
+```bash
+# Pull and run the latest image
+docker run -d \
+  -p 8080:8080 \
+  -e JWT_SECRET=your-secret \
+  -e MONGO_HOST=your-mongo-host \
+  -e MONGO_DATABASE=fitznet \
+  -e SPRING_PROFILES_ACTIVE=prod \
+  mattlol85/fitz-net-api:latest
+```
+
+---
+
+## API Reference
+
+### Authentication
+
+Protected endpoints require a `Bearer` token in the `Authorization` header, obtained from `POST /user/login`. Tokens expire after 24 hours.
+
+```
+Authorization: Bearer <token>
+```
+
+---
+
+### User Endpoints
+
+#### `POST /user/create` — public
+Create a new account.
+
+**Request body:**
+```json
+{ "username": "matt", "email": "matt@example.com", "password": "secret123" }
+```
+
+**Response `200`:**
+```json
+{ "id": "...", "username": "matt", "email": "matt@example.com", "boardColor": "hsl(210,72%,50%)" }
+```
+
+Fails `409` if username or email is already taken. Password must be at least 8 characters.
+
+---
+
+#### `POST /user/login` — public
+Authenticate and receive a JWT.
+
+**Request body:**
+```json
+{ "username": "matt", "password": "secret123" }
+```
+
+**Response `200`:**
+```json
+{
+  "success": true,
+  "message": "Login successful",
+  "username": "matt",
+  "email": "matt@example.com",
+  "boardColor": "hsl(210,72%,50%)",
+  "token": "<jwt>"
+}
+```
+
+---
+
+#### `POST /user/read` — 🔒 authenticated
+Get a user by username.
+
+**Request body:** `"matt"` (plain string)
+
+**Response `200`:**
+```json
+{ "id": "...", "username": "matt", "email": "matt@example.com", "boardColor": "hsl(210,72%,50%)" }
+```
+
+---
+
+#### `GET /user/readAll` — 🔒 authenticated
+Get all registered users.
+
+**Response `200`:** array of user objects (same shape as `/user/read`).
+
+---
+
+#### `PUT /user/update` — 🔒 authenticated
+Update the authenticated user's profile (username, email, and/or password). Identity is taken from the JWT — you cannot update another user's profile.
+
+**Request body:**
+```json
+{ "username": "matt", "email": "new@example.com", "password": "newpassword" }
+```
+`password` is optional. `username` must match the current authenticated username unless you're also changing it.
+
+**Response `200`:**
+```json
+{ "success": true, "message": "Profile updated successfully", "username": "matt", "email": "new@example.com", "boardColor": "hsl(210,72%,50%)" }
+```
+
+---
+
+#### `PATCH /user/update` — 🔒 authenticated
+Partial field update (username, email, password). Accepts any subset of fields to change.
+
+**Request body:**
+```json
+{ "username": "matt", "updatedUsername": "matt2", "updatedEmail": "new@example.com", "updatedPassword": "newpass" }
+```
+
+**Response `200`:** no body.
+
+---
+
+#### `DELETE /user/delete` — 🔒 authenticated
+Delete a user account.
+
+**Request body:**
+```json
+{ "username": "matt" }
+```
+
+**Response `200`:** no body. Fails `404` if user not found.
+
+---
+
+### Overwatch Endpoints
+
+All Overwatch endpoints require authentication. Player data is sourced from the [OverFast API](https://overfast-api.tekrop.fr) and cached for 15 minutes.
+
+---
+
+#### `GET /overwatch/search?name=<query>` — 🔒 authenticated
+Search for Overwatch players by name or BattleTag.
+
+**Response `200`:** array of player search results.
+
+---
+
+#### `POST /overwatch/profile` — 🔒 authenticated
+#### `PUT /overwatch/profile` — 🔒 authenticated
+Link (or re-link) an Overwatch player to your account. Both methods are equivalent.
+
+**Request body:**
+```json
+{ "playerId": "Zmat-1733", "gamemode": "competitive", "platform": "pc" }
+```
+
+`playerId` accepts either the BattleTag format (`Zmat#1733`) or the URL-safe format (`Zmat-1733`).
+
+**Response `200`:** your full Overwatch profile (see profile shape below).
+
+---
+
+#### `GET /overwatch/me` — 🔒 authenticated
+Get the authenticated user's linked Overwatch profile.
+
+**Response `200`:**
+```json
+{
+  "username": "matt",
+  "playerId": "Zmat-1733",
+  "battleTag": "Zmat-1733",
+  "displayName": "Zmat-1733",
+  "avatarUrl": "https://...",
+  "lastUpdatedAt": "2026-05-30T18:30:00Z",
+  "gamesWon": 278,
+  "gamesPlayed": 559,
+  "winrate": 49.73,
+  "kda": 2.27,
+  "eliminations": 6494,
+  "deaths": 3438,
+  "damage": 3213539,
+  "healing": 1677928,
+  "dpsRating": 1800,
+  "tankRating": null,
+  "healsRating": 2000,
+  "dpsPeakRating": 1800,
+  "tankPeakRating": null,
+  "healsPeakRating": 2000
+}
+```
+
+Returns `{ "username": "matt" }` (no Overwatch fields) if no profile is linked.
+
+---
+
+#### `GET /overwatch/leaderboard` — 🔒 authenticated
+Get all users with linked Overwatch profiles, sorted by average competitive rating (falls back to win rate when no rated roles).
+
+**Response `200`:** array of profile objects (same shape as `/overwatch/me`).
+
+---
+
+#### `GET /overwatch/me/history` — 🔒 authenticated
+Get rating history and cross-season progression for the authenticated user.
+
+**Response `200`:** season history including per-role rating timelines for the current season and the latest snapshot per historical season.
+
+---
+
+#### `GET /overwatch/{playerId}/history` — 🔒 authenticated
+Get public rating history for any player by BattleTag (e.g. `Zmat-1733`). Does not require the player to be registered on Fitz-Net, but per-season history is only available for registered, linked users.
+
+---
+
+### LiveBoard WebSocket
+
+A real-time shared canvas. Connect via STOMP over SockJS.
+
+| Endpoint | Description |
+|---|---|
+| `WS /ws-board` | SockJS / STOMP handshake |
+| `SUBSCRIBE /topic/board` | Receive canvas events broadcast to all clients |
+| `SEND /app/board` | Publish a canvas event |
+
+No authentication token is required to connect.
+
+---
+
+### Encryption Endpoints
+
+Symmetric AES encryption utilities (requires `ENCRYPTION_KEY` to be set).
+
+#### `POST /encrypt` — public
+**Request body:** `{ "plaintext": "hello" }`
+**Response:** `{ "ciphertext": "..." }`
+
+#### `POST /decrypt` — public
+**Request body:** `{ "ciphertext": "..." }`
+**Response:** `{ "plaintext": "hello" }`
+
+---
+
+### Actuator Endpoints
+
+| Endpoint | Auth | Description |
+|---|---|---|
+| `GET /actuator/health` | public | Service health |
+| `GET /actuator/info` | public | Build info, Git commit, Java/OS metadata |
+
+---
+
+## Data Model
+
+### User
+Stored in the `users` MongoDB collection.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | String | MongoDB ObjectId |
+| `username` | String | Lowercase, unique |
+| `email` | String | Lowercase, unique |
+| `password` | String | BCrypt hashed, never serialized |
+| `boardColor` | String | HSL color auto-assigned on registration |
+| `overwatch` | Object | Embedded `OverwatchProfile` — `null` if not linked |
+
+### OverwatchProfile (embedded)
+Stored inline on each `User` document. Fields mirror the `/overwatch/me` response.
+
+### OverwatchRatingSnapshot
+Stored in the `overwatch_rating_snapshots` collection. One document per refresh per user per season, used to build the rating history charts. Fields: `userId`, `season`, `recordedAt`, `dpsRating`, `tankRating`, `healsRating`.
+
+---
+
+## Overwatch Refresh Cron
+
+A background job runs every 30 minutes to refresh ratings for all users with a linked Overwatch profile:
+
+- Fetches current competitive ratings from OverFast
+- Writes a new `OverwatchRatingSnapshot` for the current season
+- Updates all-time peak ratings if any role hit a new high
+- Skips users refreshed within the last 20 minutes (cooldown)
+- Waits 3 seconds between each player request to stay within OverFast's Blizzard rate limits
+- Logs and skips individual failures (e.g. OverFast 503) without aborting the cycle
+
+Ratings are stored as approximate numeric SR (Bronze = 0–499, Silver = 500–999, … Champion = 3500+).
+
+To change the current season label update `overwatch.current-season` in `application.properties`.
+
+---
+
+## CI / CD
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| **Gradle Build** | Push / PR | Compiles, runs tests (embedded Mongo) |
+| **Publish Release** | Manual (`workflow_dispatch`) | Bumps version, creates Git tag, publishes GitHub Release with JAR, builds and pushes Docker image to Docker Hub |
+| **Copilot Code Review** | PR | Automated code review |
+
+To cut a release, trigger **Publish Release** from the Actions tab and choose `major`, `minor`, or `patch`.

--- a/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
@@ -11,6 +11,7 @@ import org.fitznet.fitznetapi.dto.requests.UpdateProfileRequestDto;
 import org.fitznet.fitznetapi.dto.requests.UpdateUserRequestDto;
 import org.fitznet.fitznetapi.dto.responses.LoginResponseDto;
 import org.fitznet.fitznetapi.dto.responses.UpdateProfileResponseDto;
+import org.fitznet.fitznetapi.dto.responses.UserResponseDto;
 import org.fitznet.fitznetapi.model.User;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.UserService;
@@ -40,27 +41,29 @@ public class UserController {
   @Autowired private UserRepository userRepository;
 
   @PostMapping("/user/create")
-  public User createUser(@RequestBody @Valid UserDTO user) {
+  public UserResponseDto createUser(@RequestBody @Valid UserDTO user) {
     log.info("Request at /user/create - username: {}", user.getUsername());
     performRequestValidations(user);
-    return userService.saveUser(
+    User saved = userService.saveUser(
         User.builder()
             .username(user.getUsername())
             .email(user.getEmail())
             .password(user.getPassword())
             .build());
+    return toUserResponse(saved);
   }
 
   @PostMapping("/user/read")
-  public User readUser(@RequestBody @NotBlank String username) {
+  public UserResponseDto readUser(@RequestBody @NotBlank String username) {
     log.info("Request for /user/read - {}", username);
-    return userService.readByUsername(username);
+    User user = userService.readByUsername(username);
+    return user != null ? toUserResponse(user) : null;
   }
 
   @GetMapping("/user/readAll")
-  public List<User> readAllUsers() {
+  public List<UserResponseDto> readAllUsers() {
     log.info("Request for /user/readAll");
-    return userService.findAll();
+    return userService.findAll().stream().map(UserController::toUserResponse).toList();
   }
 
   @DeleteMapping("/user/delete")
@@ -149,6 +152,10 @@ public class UserController {
     var possibleUser = userRepository.findByEmail(user.getEmail());
     log.info("Checking to see if email {} exists in db", user.getEmail());
     return null != possibleUser;
+  }
+
+  private static UserResponseDto toUserResponse(User user) {
+    return new UserResponseDto(user.getId(), user.getUsername(), user.getEmail(), user.getBoardColor());
   }
 
   private void performRequestValidations(UserDTO user) {

--- a/src/main/java/org/fitznet/fitznetapi/dto/responses/UserResponseDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/responses/UserResponseDto.java
@@ -1,0 +1,15 @@
+package org.fitznet.fitznetapi.dto.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDto {
+  String id;
+  String username;
+  String email;
+  String boardColor;
+}

--- a/src/main/java/org/fitznet/fitznetapi/model/User.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/User.java
@@ -1,7 +1,6 @@
 package org.fitznet.fitznetapi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+import org.fitznet.fitznetapi.model.overwatch.OverwatchProfile;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -29,27 +29,5 @@ public class User {
 
   String boardColor;
 
-  String overwatchPlayerId;
-  String overwatchBattleTag;
-  String overwatchDisplayName;
-  String overwatchAvatarUrl;
-  Instant overwatchLastUpdatedAt;
-  Integer overwatchGamesWon;
-  Integer overwatchGamesPlayed;
-  Double overwatchWinrate;
-  Double overwatchKda;
-  Integer overwatchEliminations;
-  Integer overwatchDeaths;
-  Integer overwatchDamage;
-  Integer overwatchHealing;
-
-  // Role-specific competitive ratings
-  Integer overwatchDpsRating;
-  Integer overwatchTankRating;
-  Integer overwatchHealsRating;
-
-  // All-time peak competitive ratings
-  Integer overwatchDpsPeakRating;
-  Integer overwatchTankPeakRating;
-  Integer overwatchHealsPeakRating;
+  OverwatchProfile overwatch;
 }

--- a/src/main/java/org/fitznet/fitznetapi/model/overwatch/OverwatchProfile.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/overwatch/OverwatchProfile.java
@@ -1,0 +1,48 @@
+package org.fitznet.fitznetapi.model.overwatch;
+
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Overwatch tracker data owned 1:1 by a {@link org.fitznet.fitznetapi.model.User}. Persisted as an
+ * embedded sub-document under the {@code overwatch} field of the {@code users} collection — it has
+ * no independent lifecycle and is never queried on its own. Time-series rating history lives
+ * separately in {@link org.fitznet.fitznetapi.model.OverwatchRatingSnapshot}.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class OverwatchProfile {
+
+  String playerId;
+  String battleTag;
+  String displayName;
+  String avatarUrl;
+  Instant lastUpdatedAt;
+
+  Integer gamesWon;
+  Integer gamesPlayed;
+  Double winrate;
+  Double kda;
+  Integer eliminations;
+  Integer deaths;
+  Integer damage;
+  Integer healing;
+
+  // Role-specific competitive ratings
+  Integer dpsRating;
+  Integer tankRating;
+  Integer healsRating;
+
+  // All-time peak competitive ratings
+  Integer dpsPeakRating;
+  Integer tankPeakRating;
+  Integer healsPeakRating;
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/OverwatchRefreshService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/OverwatchRefreshService.java
@@ -12,6 +12,7 @@ import org.fitznet.fitznetapi.dto.overfast.OverfastRoleRankDto;
 import org.fitznet.fitznetapi.dto.overfast.OverfastSummaryDto;
 import org.fitznet.fitznetapi.model.OverwatchRatingSnapshot;
 import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.model.overwatch.OverwatchProfile;
 import org.fitznet.fitznetapi.repository.OverwatchRatingSnapshotRepository;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.overwatch.CompetitiveRatings;
@@ -60,7 +61,9 @@ public class OverwatchRefreshService {
   @Scheduled(cron = "${overwatch.refresh.cron:0 */30 * * * *}")
   public void refreshAllLinkedUsers() {
     List<User> linked = userRepository.findAll().stream()
-        .filter(u -> u.getOverwatchPlayerId() != null && !u.getOverwatchPlayerId().isBlank())
+        .filter(u -> u.getOverwatch() != null
+            && u.getOverwatch().getPlayerId() != null
+            && !u.getOverwatch().getPlayerId().isBlank())
         .toList();
 
     if (linked.isEmpty()) {
@@ -81,7 +84,7 @@ public class OverwatchRefreshService {
       }
 
       try {
-        CompetitiveRatings ratings = fetchCurrentRatings(user.getOverwatchPlayerId());
+        CompetitiveRatings ratings = fetchCurrentRatings(user.getOverwatch().getPlayerId());
         saveSnapshotAndUpdatePeaks(user, ratings);
         refreshed++;
       } catch (Exception e) {
@@ -135,31 +138,36 @@ public class OverwatchRefreshService {
         .build();
     snapshotRepository.save(snapshot);
 
+    OverwatchProfile profile = user.getOverwatch();
+    if (profile == null) {
+      profile = new OverwatchProfile();
+      user.setOverwatch(profile);
+    }
     boolean peakUpdated = false;
 
     if (ratings.getDpsRating() != null
-        && (user.getOverwatchDpsPeakRating() == null
-            || ratings.getDpsRating() > user.getOverwatchDpsPeakRating())) {
-      user.setOverwatchDpsPeakRating(ratings.getDpsRating());
+        && (profile.getDpsPeakRating() == null
+            || ratings.getDpsRating() > profile.getDpsPeakRating())) {
+      profile.setDpsPeakRating(ratings.getDpsRating());
       peakUpdated = true;
     }
     if (ratings.getTankRating() != null
-        && (user.getOverwatchTankPeakRating() == null
-            || ratings.getTankRating() > user.getOverwatchTankPeakRating())) {
-      user.setOverwatchTankPeakRating(ratings.getTankRating());
+        && (profile.getTankPeakRating() == null
+            || ratings.getTankRating() > profile.getTankPeakRating())) {
+      profile.setTankPeakRating(ratings.getTankRating());
       peakUpdated = true;
     }
     if (ratings.getHealsRating() != null
-        && (user.getOverwatchHealsPeakRating() == null
-            || ratings.getHealsRating() > user.getOverwatchHealsPeakRating())) {
-      user.setOverwatchHealsPeakRating(ratings.getHealsRating());
+        && (profile.getHealsPeakRating() == null
+            || ratings.getHealsRating() > profile.getHealsPeakRating())) {
+      profile.setHealsPeakRating(ratings.getHealsRating());
       peakUpdated = true;
     }
 
-    user.setOverwatchDpsRating(ratings.getDpsRating());
-    user.setOverwatchTankRating(ratings.getTankRating());
-    user.setOverwatchHealsRating(ratings.getHealsRating());
-    user.setOverwatchLastUpdatedAt(now);
+    profile.setDpsRating(ratings.getDpsRating());
+    profile.setTankRating(ratings.getTankRating());
+    profile.setHealsRating(ratings.getHealsRating());
+    profile.setLastUpdatedAt(now);
     userRepository.save(user);
 
     if (peakUpdated) {
@@ -175,9 +183,10 @@ public class OverwatchRefreshService {
   // ---- Private helpers ----
 
   private boolean isWithinCooldown(User user) {
-    if (user.getOverwatchLastUpdatedAt() == null) return false;
+    Instant lastUpdatedAt = user.getOverwatch() != null ? user.getOverwatch().getLastUpdatedAt() : null;
+    if (lastUpdatedAt == null) return false;
     Instant cutoff = Instant.now().minus(cooldownMinutes, ChronoUnit.MINUTES);
-    return user.getOverwatchLastUpdatedAt().isAfter(cutoff);
+    return lastUpdatedAt.isAfter(cutoff);
   }
 
   static boolean isOverfastRateLimited(Exception e) {

--- a/src/main/java/org/fitznet/fitznetapi/service/OverwatchService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/OverwatchService.java
@@ -17,6 +17,7 @@ import org.fitznet.fitznetapi.dto.overwatch.OverwatchSeasonHistoryPointDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchStatsSnapshotDto;
 import org.fitznet.fitznetapi.model.OverwatchRatingSnapshot;
 import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.model.overwatch.OverwatchProfile;
 import org.fitznet.fitznetapi.repository.OverwatchRatingSnapshotRepository;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.overwatch.CompetitiveRatings;
@@ -72,29 +73,28 @@ public class OverwatchService {
     CompetitiveRatings ratings = OverwatchRefreshService.extractCompetitiveRatings(playerComplete);
     PlayerSnapshot snapshot = extractPlayerSnapshot(playerComplete, summary, internalId, normalizedInput);
 
-    user.setOverwatchPlayerId(snapshot.getPlayerId());
-    user.setOverwatchBattleTag(snapshot.getBattleTag());
-    user.setOverwatchDisplayName(snapshot.getDisplayName());
-    user.setOverwatchAvatarUrl(snapshot.getAvatarUrl());
-    user.setOverwatchLastUpdatedAt(Instant.now());
-    user.setOverwatchGamesWon(stats.getGamesWon());
-    user.setOverwatchGamesPlayed(stats.getGamesPlayed());
-    user.setOverwatchWinrate(stats.getWinrate());
-    user.setOverwatchKda(stats.getKda());
-    user.setOverwatchEliminations(stats.getEliminations());
-    user.setOverwatchDeaths(stats.getDeaths());
-    user.setOverwatchDamage(stats.getDamage());
-    user.setOverwatchHealing(stats.getHealing());
+    OverwatchProfile profile = ensureProfile(user);
+    profile.setPlayerId(snapshot.getPlayerId());
+    profile.setBattleTag(snapshot.getBattleTag());
+    profile.setDisplayName(snapshot.getDisplayName());
+    profile.setAvatarUrl(snapshot.getAvatarUrl());
+    profile.setLastUpdatedAt(Instant.now());
+    profile.setGamesWon(stats.getGamesWon());
+    profile.setGamesPlayed(stats.getGamesPlayed());
+    profile.setWinrate(stats.getWinrate());
+    profile.setKda(stats.getKda());
+    profile.setEliminations(stats.getEliminations());
+    profile.setDeaths(stats.getDeaths());
+    profile.setDamage(stats.getDamage());
+    profile.setHealing(stats.getHealing());
 
-    // Save first so user has an ID for the snapshot
+    // Save first so the user has an ID for the snapshot row.
     User saved = userRepository.save(user);
 
-    // Record snapshot and update peaks via shared refresh service
+    // Record the snapshot and update peaks on the embedded profile; persists in a single save.
     refreshService.saveSnapshotAndUpdatePeaks(saved, ratings);
 
-    // Re-fetch to get the persisted peak values
-    saved = findUser(username);
-    log.info("Attached Overwatch player {} to user {}", saved.getOverwatchPlayerId(), username);
+    log.info("Attached Overwatch player {} to user {}", saved.getOverwatch().getPlayerId(), username);
     return toProfileDto(saved);
   }
 
@@ -104,10 +104,11 @@ public class OverwatchService {
 
   public OverwatchSeasonHistoryDto getHistory(String username) {
     User user = findUser(username);
-    if (user.getOverwatchPlayerId() == null || user.getOverwatchPlayerId().isBlank()) {
+    OverwatchProfile profile = user.getOverwatch();
+    if (profile == null || profile.getPlayerId() == null || profile.getPlayerId().isBlank()) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No Overwatch profile linked to this account");
     }
-    return buildHistory(user.getOverwatchPlayerId(), user.getOverwatchBattleTag(), user);
+    return buildHistory(profile.getPlayerId(), profile.getBattleTag(), user);
   }
 
   public OverwatchSeasonHistoryDto getHistoryForPlayer(String playerId) {
@@ -120,12 +121,12 @@ public class OverwatchService {
 
   public List<OverwatchProfileDto> getLeaderboard() {
     return userRepository.findAll().stream()
-        .filter(u -> u.getOverwatchPlayerId() != null)
+        .filter(u -> u.getOverwatch() != null && u.getOverwatch().getPlayerId() != null)
         .sorted(
             Comparator.comparing(
                     OverwatchService::leaderboardScore, Comparator.nullsLast(Comparator.reverseOrder()))
                 .thenComparing(
-                    u -> defaultInteger(u.getOverwatchGamesWon()), Comparator.reverseOrder())
+                    u -> defaultInteger(u.getOverwatch().getGamesWon()), Comparator.reverseOrder())
                 .thenComparing(User::getUsername))
         .map(this::toProfileDto)
         .toList();
@@ -134,6 +135,7 @@ public class OverwatchService {
   // ---- Private helpers ----
 
   private OverwatchSeasonHistoryDto buildHistory(String playerId, String displayBattleTag, User linkedUser) {
+    OverwatchProfile linkedProfile = linkedUser != null ? linkedUser.getOverwatch() : null;
     String internalId = overwatchClient.resolveInternalPlayerId(playerId);
     OverwatchPlayerSummaryDto summary = overwatchClient.getPlayerSummary(internalId);
     OverfastPlayerCompleteDto playerComplete = overwatchClient.getCompletePlayerInfo(internalId);
@@ -227,9 +229,9 @@ public class OverwatchService {
         .dpsRating(ratings.getDpsRating())
         .tankRating(ratings.getTankRating())
         .healsRating(ratings.getHealsRating())
-        .dpsPeakRating(linkedUser != null ? linkedUser.getOverwatchDpsPeakRating() : null)
-        .tankPeakRating(linkedUser != null ? linkedUser.getOverwatchTankPeakRating() : null)
-        .healsPeakRating(linkedUser != null ? linkedUser.getOverwatchHealsPeakRating() : null)
+        .dpsPeakRating(linkedProfile != null ? linkedProfile.getDpsPeakRating() : null)
+        .tankPeakRating(linkedProfile != null ? linkedProfile.getTankPeakRating() : null)
+        .healsPeakRating(linkedProfile != null ? linkedProfile.getHealsPeakRating() : null)
         .dpsRankIcon(ratings.getDpsRankIcon())
         .tankRankIcon(ratings.getTankRankIcon())
         .healsRankIcon(ratings.getHealsRankIcon())
@@ -318,12 +320,13 @@ public class OverwatchService {
   }
 
   private static Double leaderboardScore(User user) {
+    OverwatchProfile profile = user.getOverwatch();
     double sum = 0;
     int count = 0;
-    if (user.getOverwatchDpsRating() != null)   { sum += user.getOverwatchDpsRating();   count++; }
-    if (user.getOverwatchTankRating() != null)  { sum += user.getOverwatchTankRating();  count++; }
-    if (user.getOverwatchHealsRating() != null) { sum += user.getOverwatchHealsRating(); count++; }
-    return count > 0 ? sum / count : user.getOverwatchWinrate();
+    if (profile.getDpsRating() != null)   { sum += profile.getDpsRating();   count++; }
+    if (profile.getTankRating() != null)  { sum += profile.getTankRating();  count++; }
+    if (profile.getHealsRating() != null) { sum += profile.getHealsRating(); count++; }
+    return count > 0 ? sum / count : profile.getWinrate();
   }
 
   private static Integer defaultInteger(Integer v) {
@@ -339,28 +342,43 @@ public class OverwatchService {
   }
 
   private OverwatchProfileDto toProfileDto(User user) {
+    OverwatchProfile profile = user.getOverwatch();
+    if (profile == null) {
+      // Unlinked account: return a DTO carrying only the username.
+      return OverwatchProfileDto.builder().username(user.getUsername()).build();
+    }
     return OverwatchProfileDto.builder()
         .username(user.getUsername())
-        .playerId(user.getOverwatchPlayerId())
-        .battleTag(user.getOverwatchBattleTag())
-        .displayName(user.getOverwatchDisplayName())
-        .avatarUrl(user.getOverwatchAvatarUrl())
-        .lastUpdatedAt(user.getOverwatchLastUpdatedAt())
-        .gamesWon(user.getOverwatchGamesWon())
-        .gamesPlayed(user.getOverwatchGamesPlayed())
-        .winrate(user.getOverwatchWinrate())
-        .kda(user.getOverwatchKda())
-        .eliminations(user.getOverwatchEliminations())
-        .deaths(user.getOverwatchDeaths())
-        .damage(user.getOverwatchDamage())
-        .healing(user.getOverwatchHealing())
-        .dpsRating(user.getOverwatchDpsRating())
-        .tankRating(user.getOverwatchTankRating())
-        .healsRating(user.getOverwatchHealsRating())
-        .dpsPeakRating(user.getOverwatchDpsPeakRating())
-        .tankPeakRating(user.getOverwatchTankPeakRating())
-        .healsPeakRating(user.getOverwatchHealsPeakRating())
+        .playerId(profile.getPlayerId())
+        .battleTag(profile.getBattleTag())
+        .displayName(profile.getDisplayName())
+        .avatarUrl(profile.getAvatarUrl())
+        .lastUpdatedAt(profile.getLastUpdatedAt())
+        .gamesWon(profile.getGamesWon())
+        .gamesPlayed(profile.getGamesPlayed())
+        .winrate(profile.getWinrate())
+        .kda(profile.getKda())
+        .eliminations(profile.getEliminations())
+        .deaths(profile.getDeaths())
+        .damage(profile.getDamage())
+        .healing(profile.getHealing())
+        .dpsRating(profile.getDpsRating())
+        .tankRating(profile.getTankRating())
+        .healsRating(profile.getHealsRating())
+        .dpsPeakRating(profile.getDpsPeakRating())
+        .tankPeakRating(profile.getTankPeakRating())
+        .healsPeakRating(profile.getHealsPeakRating())
         .build();
+  }
+
+  /** Returns the user's embedded Overwatch profile, creating and attaching it if absent. */
+  private static OverwatchProfile ensureProfile(User user) {
+    OverwatchProfile profile = user.getOverwatch();
+    if (profile == null) {
+      profile = new OverwatchProfile();
+      user.setOverwatch(profile);
+    }
+    return profile;
   }
 
   private static String normalizeBattleTag(String value) {

--- a/src/test/java/org/fitznet/fitznetapi/controller/UserControllerTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/controller/UserControllerTest.java
@@ -14,6 +14,7 @@ import org.fitznet.fitznetapi.dto.requests.UpdateProfileRequestDto;
 import org.fitznet.fitznetapi.dto.requests.UpdateUserRequestDto;
 import org.fitznet.fitznetapi.dto.responses.LoginResponseDto;
 import org.fitznet.fitznetapi.dto.responses.UpdateProfileResponseDto;
+import org.fitznet.fitznetapi.dto.responses.UserResponseDto;
 import org.fitznet.fitznetapi.model.User;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.UserService;
@@ -69,7 +70,7 @@ class UserControllerTest {
     when(userRepository.findByEmail(userDTO.getEmail()))
         .thenReturn(null); // Ensuring email doesn't exist
 
-    User createdUser = userController.createUser(userDTO);
+    UserResponseDto createdUser = userController.createUser(userDTO);
 
     assertNotNull(createdUser);
     assertEquals("mattlol85", createdUser.getUsername());
@@ -88,7 +89,7 @@ class UserControllerTest {
 
     when(userService.readByUsername(username)).thenReturn(user);
 
-    User foundUser = userController.readUser(username);
+    UserResponseDto foundUser = userController.readUser(username);
 
     assertNotNull(foundUser);
     assertEquals(username, foundUser.getUsername());
@@ -101,7 +102,7 @@ class UserControllerTest {
 
     when(userService.readByUsername(username)).thenReturn(null);
 
-    User foundUser = userController.readUser(username);
+    UserResponseDto foundUser = userController.readUser(username);
 
     assertNull(foundUser);
     verify(userService, times(1)).readByUsername(username);
@@ -118,7 +119,7 @@ class UserControllerTest {
 
     when(userService.findAll()).thenReturn(Collections.singletonList(user));
 
-    List<User> users = userController.readAllUsers();
+    List<UserResponseDto> users = userController.readAllUsers();
 
     assertNotNull(users);
     assertEquals(1, users.size());

--- a/src/test/java/org/fitznet/fitznetapi/service/OverwatchRefreshServiceTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/OverwatchRefreshServiceTest.java
@@ -21,6 +21,7 @@ import org.fitznet.fitznetapi.dto.overfast.OverfastRoleRankDto;
 import org.fitznet.fitznetapi.dto.overfast.OverfastSummaryDto;
 import org.fitznet.fitznetapi.model.OverwatchRatingSnapshot;
 import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.model.overwatch.OverwatchProfile;
 import org.fitznet.fitznetapi.repository.OverwatchRatingSnapshotRepository;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.overwatch.CompetitiveRatings;
@@ -95,9 +96,11 @@ class OverwatchRefreshServiceTest {
   @Test
   void saveSnapshotShouldUpdatePeakWhenCurrentRatingExceedsPrevious() {
     User user = User.builder().id("u1").username("matt")
-        .overwatchDpsPeakRating(2700)
-        .overwatchTankPeakRating(2600)
-        .overwatchHealsPeakRating(2900)
+        .overwatch(OverwatchProfile.builder()
+            .dpsPeakRating(2700)
+            .tankPeakRating(2600)
+            .healsPeakRating(2900)
+            .build())
         .build();
     CompetitiveRatings ratings = new CompetitiveRatings(2800, 2550, 2950, null, null, null);
 
@@ -107,10 +110,10 @@ class OverwatchRefreshServiceTest {
 
     refreshService.saveSnapshotAndUpdatePeaks(user, ratings);
 
-    User savedUser = userCaptor.getValue();
-    assertEquals(2800, savedUser.getOverwatchDpsPeakRating()); // updated (2800 > 2700)
-    assertEquals(2600, savedUser.getOverwatchTankPeakRating()); // unchanged (2550 < 2600)
-    assertEquals(2950, savedUser.getOverwatchHealsPeakRating()); // updated (2950 > 2900)
+    OverwatchProfile saved = userCaptor.getValue().getOverwatch();
+    assertEquals(2800, saved.getDpsPeakRating()); // updated (2800 > 2700)
+    assertEquals(2600, saved.getTankPeakRating()); // unchanged (2550 < 2600)
+    assertEquals(2950, saved.getHealsPeakRating()); // updated (2950 > 2900)
   }
 
   @Test
@@ -124,10 +127,10 @@ class OverwatchRefreshServiceTest {
 
     refreshService.saveSnapshotAndUpdatePeaks(user, ratings);
 
-    User savedUser = userCaptor.getValue();
-    assertEquals(2800, savedUser.getOverwatchDpsPeakRating());
-    assertEquals(2600, savedUser.getOverwatchTankPeakRating());
-    assertNull(savedUser.getOverwatchHealsPeakRating()); // null rating = no peak update
+    OverwatchProfile saved = userCaptor.getValue().getOverwatch();
+    assertEquals(2800, saved.getDpsPeakRating());
+    assertEquals(2600, saved.getTankPeakRating());
+    assertNull(saved.getHealsPeakRating()); // null rating = no peak update
   }
 
   // ---- cron job cooldown ----
@@ -136,13 +139,17 @@ class OverwatchRefreshServiceTest {
   void cronShouldSkipUsersRefreshedWithinCooldownWindow() {
     User recentUser = User.builder()
         .id("u1").username("recent")
-        .overwatchPlayerId("Recent-1")
-        .overwatchLastUpdatedAt(Instant.now().minus(5, ChronoUnit.MINUTES))
+        .overwatch(OverwatchProfile.builder()
+            .playerId("Recent-1")
+            .lastUpdatedAt(Instant.now().minus(5, ChronoUnit.MINUTES))
+            .build())
         .build();
     User staleUser = User.builder()
         .id("u2").username("stale")
-        .overwatchPlayerId("Stale-1")
-        .overwatchLastUpdatedAt(Instant.now().minus(30, ChronoUnit.MINUTES))
+        .overwatch(OverwatchProfile.builder()
+            .playerId("Stale-1")
+            .lastUpdatedAt(Instant.now().minus(30, ChronoUnit.MINUTES))
+            .build())
         .build();
 
     OverfastPlayerCompleteDto emptyComplete = new OverfastPlayerCompleteDto();
@@ -159,8 +166,10 @@ class OverwatchRefreshServiceTest {
 
   @Test
   void cronShouldContinueAfterSingleUserFailure() {
-    User failUser = User.builder().id("u1").username("fail").overwatchPlayerId("Fail-1").build();
-    User okUser = User.builder().id("u2").username("ok").overwatchPlayerId("Ok-1").build();
+    User failUser = User.builder().id("u1").username("fail")
+        .overwatch(OverwatchProfile.builder().playerId("Fail-1").build()).build();
+    User okUser = User.builder().id("u2").username("ok")
+        .overwatch(OverwatchProfile.builder().playerId("Ok-1").build()).build();
 
     when(userRepository.findAll()).thenReturn(List.of(failUser, okUser));
     when(overwatchClient.getCompletePlayerInfo("Fail-1"))

--- a/src/test/java/org/fitznet/fitznetapi/service/OverwatchServiceTest.java
+++ b/src/test/java/org/fitznet/fitznetapi/service/OverwatchServiceTest.java
@@ -15,6 +15,7 @@ import org.fitznet.fitznetapi.dto.overfast.OverfastStatsTotalsDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchPlayerSummaryDto;
 import org.fitznet.fitznetapi.dto.overwatch.OverwatchProfileDto;
 import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.model.overwatch.OverwatchProfile;
 import org.fitznet.fitznetapi.repository.OverwatchRatingSnapshotRepository;
 import org.fitznet.fitznetapi.repository.UserRepository;
 import org.fitznet.fitznetapi.service.overwatch.CompetitiveRatings;
@@ -95,23 +96,20 @@ class OverwatchServiceTest {
     User best =
         User.builder()
             .username("best")
-            .overwatchPlayerId("Best-1")
-            .overwatchWinrate(65.0)
-            .overwatchGamesWon(20)
+            .overwatch(OverwatchProfile.builder()
+                .playerId("Best-1").winrate(65.0).gamesWon(20).build())
             .build();
     User tieWinner =
         User.builder()
             .username("tieWinner")
-            .overwatchPlayerId("Tie-1")
-            .overwatchWinrate(55.0)
-            .overwatchGamesWon(30)
+            .overwatch(OverwatchProfile.builder()
+                .playerId("Tie-1").winrate(55.0).gamesWon(30).build())
             .build();
     User tieLoser =
         User.builder()
             .username("tieLoser")
-            .overwatchPlayerId("Tie-2")
-            .overwatchWinrate(55.0)
-            .overwatchGamesWon(10)
+            .overwatch(OverwatchProfile.builder()
+                .playerId("Tie-2").winrate(55.0).gamesWon(10).build())
             .build();
     User unattached = User.builder().username("nope").build();
 


### PR DESCRIPTION
## Summary

Two follow-up changes to the OverwatchProfile embedding refactor (merged in #29):

- **Fix: stop returning raw \`User\` entities from user endpoints** — \`UserController\` was serializing the full domain model on \`/user/create\`, \`/user/read\`, and \`/user/readAll\`. After the embedding refactor the JSON shape of those responses changed (22 flat \`overwatch*\` nulls → nested \`overwatch: null\`). Introduced \`UserResponseDto(id, username, email, boardColor)\` so the contract is explicit and stable. Note: the frontend does not need changes — it never calls \`/user/read\` or \`/user/readAll\`, and \`api.js createUser\` only reads \`id\`/\`username\`/\`email\`, none of which changed.

- **Docs: rewrite README** — replaced the boilerplate Spring Initializr README with full project documentation: quick start, environment variables, complete endpoint reference (User, Overwatch, LiveBoard WebSocket, Encryption, Actuator), data model, Overwatch cron behaviour, and CI/CD pipeline overview.

## Test plan

- [ ] \`./gradlew build\` passes (all existing tests updated for \`UserResponseDto\` return types)
- [ ] \`/user/create\` response contains \`id\`, \`username\`, \`email\`, \`boardColor\` — no \`overwatch\` field
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)