### PR TITLE
feat(auth): Password reset via self-hosted fitznet.org email

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("com.google.code.gson:gson:2.11.0")
 

--- a/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
+++ b/src/main/java/org/fitznet/fitznetapi/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers(HttpMethod.OPTIONS, "/**")
                     .permitAll()
-                    .requestMatchers("/user/create", "/user/login")
+                    .requestMatchers("/user/create", "/user/login", "/user/forgot-password", "/user/reset-password")
                     .permitAll()
                     .requestMatchers("/encrypt", "/decrypt")
                     .permitAll()

--- a/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
+++ b/src/main/java/org/fitznet/fitznetapi/controller/UserController.java
@@ -2,11 +2,13 @@ package org.fitznet.fitznetapi.controller;
 
 import jakarta.validation.Valid;
 import java.util.List;
-
+import java.util.Map;
 import jakarta.validation.constraints.NotBlank;
 import org.fitznet.fitznetapi.dto.UserDTO;
 import org.fitznet.fitznetapi.dto.requests.DeleteUserRequestDto;
+import org.fitznet.fitznetapi.dto.requests.ForgotPasswordRequestDto;
 import org.fitznet.fitznetapi.dto.requests.LoginRequestDto;
+import org.fitznet.fitznetapi.dto.requests.ResetPasswordRequestDto;
 import org.fitznet.fitznetapi.dto.requests.UpdateProfileRequestDto;
 import org.fitznet.fitznetapi.dto.requests.UpdateUserRequestDto;
 import org.fitznet.fitznetapi.dto.responses.LoginResponseDto;
@@ -14,12 +16,14 @@ import org.fitznet.fitznetapi.dto.responses.UpdateProfileResponseDto;
 import org.fitznet.fitznetapi.dto.responses.UserResponseDto;
 import org.fitznet.fitznetapi.model.User;
 import org.fitznet.fitznetapi.repository.UserRepository;
+import org.fitznet.fitznetapi.service.PasswordResetService;
 import org.fitznet.fitznetapi.service.UserService;
 import org.fitznet.fitznetapi.util.JwtUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -36,6 +40,7 @@ public class UserController {
 
   @Autowired UserService userService;
   @Autowired JwtUtil jwtUtil;
+  @Autowired PasswordResetService passwordResetService;
 
   static final Logger log = LoggerFactory.getLogger(UserController.class);
   @Autowired private UserRepository userRepository;
@@ -134,6 +139,23 @@ public class UserController {
     } else {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid username or password");
     }
+  }
+
+  @PostMapping("/user/forgot-password")
+  public ResponseEntity<Map<String, Object>> forgotPassword(@RequestBody @Valid ForgotPasswordRequestDto request) {
+    log.info("Request for /user/forgot-password");
+    passwordResetService.initiateReset(request.getEmail());
+    return ResponseEntity.ok(Map.of("success", true, "message", "If that email is registered, a reset link has been sent."));
+  }
+
+  @PostMapping("/user/reset-password")
+  public ResponseEntity<Map<String, Object>> resetPassword(@RequestBody @Valid ResetPasswordRequestDto request) {
+    log.info("Request for /user/reset-password");
+    boolean success = passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
+    if (!success) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid or expired reset token");
+    }
+    return ResponseEntity.ok(Map.of("success", true, "message", "Password reset successfully"));
   }
 
   private boolean doesUserAlreadyExist(String username) {

--- a/src/main/java/org/fitznet/fitznetapi/dto/requests/ForgotPasswordRequestDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/requests/ForgotPasswordRequestDto.java
@@ -1,0 +1,13 @@
+package org.fitznet.fitznetapi.dto.requests;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ForgotPasswordRequestDto {
+
+  @NotBlank
+  @Email
+  private String email;
+}

--- a/src/main/java/org/fitznet/fitznetapi/dto/requests/ResetPasswordRequestDto.java
+++ b/src/main/java/org/fitznet/fitznetapi/dto/requests/ResetPasswordRequestDto.java
@@ -1,0 +1,16 @@
+package org.fitznet.fitznetapi.dto.requests;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ResetPasswordRequestDto {
+
+  @NotBlank
+  private String token;
+
+  @NotBlank
+  @Size(min = 8, message = "Password must be at least 8 characters long")
+  private String newPassword;
+}

--- a/src/main/java/org/fitznet/fitznetapi/model/PasswordResetToken.java
+++ b/src/main/java/org/fitznet/fitznetapi/model/PasswordResetToken.java
@@ -1,0 +1,30 @@
+package org.fitznet.fitznetapi.model;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "password_reset_tokens")
+public class PasswordResetToken {
+
+  @Id
+  private String id;
+
+  @Indexed
+  private String email;
+
+  private String token;
+
+  private LocalDateTime expiresAt;
+
+  private boolean used;
+}

--- a/src/main/java/org/fitznet/fitznetapi/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/org/fitznet/fitznetapi/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,14 @@
+package org.fitznet.fitznetapi.repository;
+
+import java.util.Optional;
+import org.fitznet.fitznetapi.model.PasswordResetToken;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PasswordResetTokenRepository extends MongoRepository<PasswordResetToken, String> {
+
+  Optional<PasswordResetToken> findByTokenAndUsedFalse(String token);
+
+  void deleteByEmail(String email);
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/EmailService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/EmailService.java
@@ -1,0 +1,39 @@
+package org.fitznet.fitznetapi.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class EmailService {
+
+  private final JavaMailSender mailSender;
+
+  @Value("${mail.from}")
+  private String from;
+
+  @Value("${app.base-url}")
+  private String appBaseUrl;
+
+  public EmailService(JavaMailSender mailSender) {
+    this.mailSender = mailSender;
+  }
+
+  public void sendPasswordReset(String toEmail, String resetToken) {
+    String resetUrl = appBaseUrl + "/reset-password?token=" + resetToken;
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setFrom(from);
+    message.setTo(toEmail);
+    message.setSubject("Fitz-Net Password Reset");
+    message.setText(
+        "You requested a password reset for your Fitz-Net account.\n\n"
+            + "Click the link below to reset your password (expires in 15 minutes):\n\n"
+            + resetUrl
+            + "\n\nIf you did not request this, you can safely ignore this email.");
+    mailSender.send(message);
+    log.info("Password reset email sent to {}", toEmail);
+  }
+}

--- a/src/main/java/org/fitznet/fitznetapi/service/PasswordResetService.java
+++ b/src/main/java/org/fitznet/fitznetapi/service/PasswordResetService.java
@@ -1,0 +1,76 @@
+package org.fitznet.fitznetapi.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.fitznet.fitznetapi.model.PasswordResetToken;
+import org.fitznet.fitznetapi.model.User;
+import org.fitznet.fitznetapi.repository.PasswordResetTokenRepository;
+import org.fitznet.fitznetapi.repository.UserRepository;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class PasswordResetService {
+
+  private final UserRepository userRepository;
+  private final PasswordResetTokenRepository tokenRepository;
+  private final EmailService emailService;
+  private final PasswordEncoder passwordEncoder;
+  private final MongoTemplate mongoTemplate;
+
+  public PasswordResetService(
+      UserRepository userRepository,
+      PasswordResetTokenRepository tokenRepository,
+      EmailService emailService,
+      PasswordEncoder passwordEncoder,
+      MongoTemplate mongoTemplate) {
+    this.userRepository = userRepository;
+    this.tokenRepository = tokenRepository;
+    this.emailService = emailService;
+    this.passwordEncoder = passwordEncoder;
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  public void initiateReset(String email) {
+    User user = userRepository.findByEmail(email);
+    if (user == null) {
+      // Return silently — never reveal whether an email is registered
+      log.debug("Password reset requested for unknown email: {}", email);
+      return;
+    }
+
+    tokenRepository.deleteByEmail(email);
+
+    PasswordResetToken token = PasswordResetToken.builder()
+        .email(email)
+        .token(UUID.randomUUID().toString())
+        .expiresAt(LocalDateTime.now().plusMinutes(15))
+        .used(false)
+        .build();
+
+    tokenRepository.save(token);
+    emailService.sendPasswordReset(email, token.getToken());
+  }
+
+  public boolean resetPassword(String rawToken, String newPassword) {
+    return tokenRepository.findByTokenAndUsedFalse(rawToken)
+        .filter(t -> t.getExpiresAt().isAfter(LocalDateTime.now()))
+        .map(t -> {
+          Query query = new Query(Criteria.where("email").is(t.getEmail()));
+          Update update = new Update().set("password", passwordEncoder.encode(newPassword));
+          mongoTemplate.updateFirst(query, update, User.class);
+
+          t.setUsed(true);
+          tokenRepository.save(t);
+          log.info("Password reset successfully for {}", t.getEmail());
+          return true;
+        })
+        .orElse(false);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,14 @@ overwatch.current-season=Season 16
 
 # Caffeine cache TTL (in seconds) for OverFast player data
 spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=900s
+
+# Mail / SMTP configuration (set via environment variables in production)
+spring.mail.host=${MAIL_HOST:mail.fitznet.org}
+spring.mail.port=${MAIL_PORT:587}
+spring.mail.username=${MAIL_USERNAME:noreply@fitznet.org}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+mail.from=noreply@fitznet.org
+app.base-url=${APP_BASE_URL:https://fitznet.org}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,3 +13,14 @@ spring.mongodb.embedded.version=4.0.28
 management.health.mongo.enabled=false
 management.endpoints.web.exposure.include=health,info
 
+# Mail configuration for tests (uses local SMTP stub)
+spring.mail.host=localhost
+spring.mail.port=3025
+spring.mail.username=test
+spring.mail.password=test
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
+spring.mail.properties.mail.smtp.starttls.required=false
+mail.from=noreply@fitznet.org
+app.base-url=https://fitznet.org
+


### PR DESCRIPTION
## Summary

Adds a complete forgot-password / reset-password flow to the Fitz-Net API, backed by the new self-hosted `mail.fitznet.org` mail server.

- **`POST /user/forgot-password`** (public) — accepts `{ email }`, generates a 15-minute UUID token, saves it to MongoDB, and sends a reset link to the user's registered email via `noreply@fitznet.org`
- **`POST /user/reset-password`** (public) — accepts `{ token, newPassword }`, validates token (not used, not expired), BCrypt-hashes and stores the new password, marks token used
- Silently no-ops for unknown emails (prevents email enumeration)
- `spring-boot-starter-mail` added; SMTP config is env-var driven (`MAIL_HOST`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `APP_BASE_URL`)

## New Files

| File | Purpose |
|------|---------|
| `model/PasswordResetToken.java` | MongoDB document: token, email, expiry, used flag |
| `repository/PasswordResetTokenRepository.java` | `findByTokenAndUsedFalse`, `deleteByEmail` |
| `dto/requests/ForgotPasswordRequestDto.java` | `{ email }` with `@Email` validation |
| `dto/requests/ResetPasswordRequestDto.java` | `{ token, newPassword }` with `@Size(min=8)` |
| `service/EmailService.java` | Sends reset email via `JavaMailSender` |
| `service/PasswordResetService.java` | Orchestrates token lifecycle and password update |

## Modified Files

| File | Change |
|------|--------|
| `build.gradle.kts` | Add `spring-boot-starter-mail` |
| `application.properties` | Add SMTP + app base URL config |
| `controller/UserController.java` | Add 2 new endpoints |
| `config/SecurityConfig.java` | Permit `/user/forgot-password` and `/user/reset-password` |
| `src/test/resources/application.properties` | Stub mail config for test context startup |

## Infrastructure Dependency

Requires the mail server stack from the [Fitz-Net-Agent-Sandbox `mail/` directory](https://github.com/mattlol85/Fitz-Net-Agent-Sandbox) to be running on `mail.fitznet.org`. See `mail/SETUP.md` for setup steps.

## Test Plan

- [ ] All 114 existing tests pass (`./gradlew test`)
- [ ] `POST /user/forgot-password` with a registered email → email arrives at inbox
- [ ] `POST /user/forgot-password` with unknown email → returns 200 OK (no leak)
- [ ] Token link works in browser → redirects to `/reset-password?token=...`
- [ ] `POST /user/reset-password` with valid token + new password → `POST /user/login` with new password succeeds
- [ ] Expired token (>15 min) → 400 Bad Request
- [ ] Already-used token → 400 Bad Request

🤖 Generated with [Claude Code](https://claude.com/claude-code)